### PR TITLE
chore: Redis 기반 RefreshToken 엔티티 및 Repository 추가

### DIFF
--- a/src/main/java/site/sonisori/sonisori/auth/jwt/entity/RefreshToken.java
+++ b/src/main/java/site/sonisori/sonisori/auth/jwt/entity/RefreshToken.java
@@ -1,0 +1,18 @@
+package site.sonisori.sonisori.auth.jwt.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@RedisHash(value = "refreshToken", timeToLive = 1209600)
+public class RefreshToken {
+	@Id
+	private String refreshToken;
+	private Long userId;
+}

--- a/src/main/java/site/sonisori/sonisori/auth/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/site/sonisori/sonisori/auth/jwt/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package site.sonisori.sonisori.auth.jwt.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import site.sonisori.sonisori.auth.jwt.entity.RefreshToken;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- refresh token을 저장하기 위한 초기 설정을 추가하였습니다
- 14일간 저장합니다.

### 논의 사항 (선택)
- refresh token은 jwt가 아니라 UUID로 저장하면 좋을 것 같습니다 

closed #11 