### PR TITLE
feat: global error 처리 및 사용자 정의 error response 추가

### DIFF
--- a/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
+++ b/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
@@ -1,0 +1,17 @@
+package site.sonisori.sonisori.common.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+	INVALID_REQUEST("유효하지 않은 요청입니다."),
+	SERVER_ERROR("서버 오류가 발생했습니다."),
+	NOT_FOUND_TOKEN("토큰이 존재하지 않습니다."),
+	INVALID_TOKEN("유효하지 않은 토큰입니다."),
+	METHOD_VALIDATION_FAILED("메서드 유효성 검사에 실패했습니다."),
+	NULL_POINTER_EXCEPTION("서버에서 null 참조 오류가 발생했습니다.");
+
+	private final String message;
+}

--- a/src/main/java/site/sonisori/sonisori/common/response/ErrorResponse.java
+++ b/src/main/java/site/sonisori/sonisori/common/response/ErrorResponse.java
@@ -1,0 +1,6 @@
+package site.sonisori.sonisori.common.response;
+
+public record ErrorResponse(
+	String message
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
@@ -1,0 +1,63 @@
+package site.sonisori.sonisori.exception;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+import site.sonisori.sonisori.common.constants.ErrorMessage;
+import site.sonisori.sonisori.common.response.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+	private static final String DEFAULT_MESSAGE = ErrorMessage.INVALID_REQUEST.getMessage();
+
+	@ExceptionHandler(HandlerMethodValidationException.class)
+	public ResponseEntity<ErrorResponse> handlerMethodValidationException(HandlerMethodValidationException ex) {
+		String errorMessage = ex.getAllValidationResults()
+			.getFirst()
+			.getResolvableErrors()
+			.getFirst()
+			.getDefaultMessage();
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(new ErrorResponse(errorMessage));
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+		List<FieldError> fieldErrors = ex.getFieldErrors();
+		String errorMessage = fieldErrors.stream()
+			.map(FieldError::getDefaultMessage)
+			.filter(Objects::nonNull)
+			.findFirst()
+			.orElse(ErrorMessage.METHOD_VALIDATION_FAILED.getMessage());
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(new ErrorResponse(errorMessage));
+	}
+
+	@ExceptionHandler(NullPointerException.class)
+	public ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException ex) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(new ErrorResponse(ErrorMessage.NULL_POINTER_EXCEPTION.getMessage()));
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(new ErrorResponse(ErrorMessage.SERVER_ERROR.getMessage()));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(new ErrorResponse(ErrorMessage.SERVER_ERROR.getMessage()));
+	}
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- `GlobalExceptionHandler`를 추가하여 `NullPointerException`, `MethodArgumentNotValidException`, `HandlerMethodValidationException` 등을 처리하는 글로벌 예외 처리 로직 구현.
- `ErrorMessage` enum에 예외에 대한 상세한 메시지 제공.
- `ErrorResponse` 클래스를 활용하여 일관된 에러 응답 포맷 제공.

### PR Point
- 에러 메시지의 일관성과 사용자 친화성을 확인해 주세요.

closed #14 