### PR TITLE
feat: slf4j 로그 설정 추가 및 적용

### DIFF
--- a/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(HandlerMethodValidationException.class)
 	public ResponseEntity<ErrorResponse> handlerMethodValidationException(HandlerMethodValidationException ex) {
-		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
+		logException(ex);
 		String errorMessage = ex.getAllValidationResults()
 			.getFirst()
 			.getResolvableErrors()
@@ -35,7 +35,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
+		logException(ex);
 		List<FieldError> fieldErrors = ex.getFieldErrors();
 		String errorMessage = fieldErrors.stream()
 			.map(FieldError::getDefaultMessage)
@@ -49,22 +49,26 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(NullPointerException.class)
 	public ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException ex) {
-		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
+		logException(ex);
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ErrorResponse(ErrorMessage.NULL_POINTER_EXCEPTION.getMessage()));
 	}
 
 	@ExceptionHandler(RuntimeException.class)
 	public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
-		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
+		logException(ex);
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ErrorResponse(ErrorMessage.SERVER_ERROR.getMessage()));
 	}
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception ex) {
-		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
+		logException(ex);
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ErrorResponse(ErrorMessage.SERVER_ERROR.getMessage()));
+	}
+
+	private void logException(Exception ex) {
+		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
@@ -11,15 +11,18 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
+import lombok.extern.slf4j.Slf4j;
 import site.sonisori.sonisori.common.constants.ErrorMessage;
 import site.sonisori.sonisori.common.response.ErrorResponse;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 	private static final String DEFAULT_MESSAGE = ErrorMessage.INVALID_REQUEST.getMessage();
 
 	@ExceptionHandler(HandlerMethodValidationException.class)
 	public ResponseEntity<ErrorResponse> handlerMethodValidationException(HandlerMethodValidationException ex) {
+		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		String errorMessage = ex.getAllValidationResults()
 			.getFirst()
 			.getResolvableErrors()
@@ -32,6 +35,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		List<FieldError> fieldErrors = ex.getFieldErrors();
 		String errorMessage = fieldErrors.stream()
 			.map(FieldError::getDefaultMessage)
@@ -45,18 +49,21 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(NullPointerException.class)
 	public ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException ex) {
+		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ErrorResponse(ErrorMessage.NULL_POINTER_EXCEPTION.getMessage()));
 	}
 
 	@ExceptionHandler(RuntimeException.class)
 	public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
+		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ErrorResponse(ErrorMessage.SERVER_ERROR.getMessage()));
 	}
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ErrorResponse(ErrorMessage.SERVER_ERROR.getMessage()));
 	}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss} [%thread] %clr(%5level) %cyan(%logger) - %msg%n"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
+    <springProperty name="LOG_PATH" source="logging.file.path"/>
+    <!-- 콘솔로그 Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일로그 Appender -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/app/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/error/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- local profile -->
+    <springProfile name="local">
+        <logger name="site.coach_coach.coach_coach_server" level="DEBUG"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+    <!-- dev profile -->
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+            <appender-ref ref="ERROR_FILE"/>
+        </root>
+    </springProfile>
+    <!-- prod profile -->
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+            <appender-ref ref="ERROR_FILE"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
# Pull requests
### 작업한 내용
**application properties에 다음 내용을 추가해주세요!!!!**
```properties
# log
spring.profiles.active=local
logging.config=classpath:logback-spring.xml
logging.file.path=./logs
```
- 로그 설정을 위해 `logback-spring.xml` 설정 파일을 작성하였습니다.
  - 콘솔 및 파일 로그 출력 형식을 일관성 있게 적용하였습니다.
  - 로컬 환경에서는 console만 나오고, 개발 환경과 운영 환경에서는 콘솔과 더불어 파일까지 저장됩니다.
  - 개발환경의 설정에서 작업하고 로그 파일로 저장하고 싶다면 `application.properties`의 `spring.profiles.active` 부분을 `dev`로 수정하면 됩니다!
- `GlobalExceptionHandler` 클래스 예외 처리가 필요한 파일에서 예외 처리 시 로깅을 적용하였습니다
- console 찍을 일이 있다면 console 대신 `log.info()`로 찍어서 확인하시면 됩니다! 그 후 필요없는 로그는 지워주세요! 

### PR Point
- 로깅 레벨(INFO, WARN, ERROR)이 적절히 설정되어 있는지 확인해 주세요.
- 로그 메시지가 적절한 레벨로 기록되고 있는지, 그리고 필요한 정보가 포함되어 있는지 중점적으로 봐 주세요.
- 추가적인 로깅 정보나 형식 개선에 대한 의견이 있으시면 말씀해주세요!!
- 파일의 경우 전체적인 로그를 저장하는 파일과 에러 메시지만 저장하는 파일 두 가지를 생성합니다.
  - 파일의 최대 사이즈는 100MB이며, 최대 30일간의 로그 파일을 보관합니다
  - 로그 파일은 날짜별로 생성되며, 예를 들어 파일의 크기가 큰 경우 `2024-10-25.0.log`, `2024-10-25.1.log`와 같은 형식으로 저장됩니다.

### 📸 스크린샷

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/16ae282c-00c7-4ef2-a865-bc5ecb2ba5a2)| `application.properties`의 `local`을 `dev`로 수정시 파일로 로그 저장 |

### 정보 공유 (로그 레벨)
- **Fatal**
    - 매우 심각한 에러.
    - 프로그램이 종료되는 경우가 많음. (작성되지 않기 때문에 작성하지 않기도 함)
- **Error**
    - 의도하지 않은 에러가 발생한 경우 (프로그램 내에서 개발자가 의도하지 않은 예외를 나타낼 때 사용)
    - 프로그램이 종료되진 않음
    - *ex : 외부 api 요청에 에러가 발생한 경우*
- **Warn**
    - 에러가 될 수 있는 잠재적 가능성이 있는 경우
    - 이러한 로그가 발생했을 때 알람을 통해 개발자가 크리티컬한 에러를 맞닥뜨리기 전 해결할 수 있는 경우 사용
- **Info**
    - 명확한 의도가 있는 에러
    - 요구사항에 따라 시스템 동작을 보여줄 때
- **Debug**
    - Info 레벨보다 더 자세한 정보가 필요한 경우.
    - 개발 혹은 테스트 단계에서 해당 기능들이 올바르게 작동하는지 확인하기 위한 로그 레벨
- **Trace**
    - Debug 레벨보다 더 자세함
    - Dev 환경에서 버그를 해결하기 위해 사용

closed #16 