### PR TITLE
fix: V1 sql의 social type enum 수정

### DIFF
--- a/src/main/java/site/sonisori/sonisori/common/SocialType.java
+++ b/src/main/java/site/sonisori/sonisori/common/SocialType.java
@@ -1,5 +1,5 @@
 package site.sonisori.sonisori.common;
 
 public enum SocialType {
-	google, kakao
+	naver, kakao, none
 }

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS `sonisori`.`users` (
     `email` VARCHAR(45) NOT NULL,
     `role` ENUM('ROLE_USER','ROLE_ADMIN') NOT NULL DEFAULT 'ROLE_USER',
     `username` VARCHAR(500) NOT NULL,
-    `social_type` ENUM('kakao','naver') NOT NULL,
+    `social_type` ENUM('kakao','naver', 'none') NOT NULL,
     `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
     `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP(),
     PRIMARY KEY (`id`)

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS `sonisori`.`users` (
     `email` VARCHAR(45) NOT NULL,
     `role` ENUM('ROLE_USER','ROLE_ADMIN') NOT NULL DEFAULT 'ROLE_USER',
     `username` VARCHAR(500) NOT NULL,
-    `social_type` ENUM('kakao','google') NOT NULL,
+    `social_type` ENUM('kakao','naver') NOT NULL,
     `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
     `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP(),
     PRIMARY KEY (`id`)


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- DB의 social type enum이 잘못 설정되어 있어 문제가 발생하므로 이를 수정하였습니다. 

### PR Point
- **_반드시 코드 실행 전에 mysql을 비워주세요_**

![image](https://github.com/user-attachments/assets/4e04a680-a38c-454e-a339-e69dcbee0a1f)
여기서 Drop Schema를 눌러 Schema를 삭제해주세요

![image](https://github.com/user-attachments/assets/bd82622a-035c-48e5-8efb-83f607db553d)
그 후 해당 왼쪽 빈 화면에서 우클릭 후 Create Schema를 눌러 sonisori라는 schema를 생성해주세요
그리고 코드를 실행해주시기 바랍니다


### 논의 사항 (선택)
- 원래 sql 파일을 한 번 만든 후 고치면 안 되지만 db안의 내용이 없어 임의로 수정하였습니다. 이점 유의해주시기 바랍니다
- 자체 회원가입과 로그인을 위한 `password` 필드도 추가하려고 했으나 entity와 함께 바꿔야해서 복잡해질까봐 처리하지 않았습니다.


closed #24 