### PR TITLE
feat: 자체 로그인 api 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/auth/oauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/site/sonisori/sonisori/auth/oauth2/CustomOAuth2SuccessHandler.java
@@ -34,12 +34,14 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 		User user = customUserDetails.getUser();
 
 		TokenDto tokenDto = jwtUtil.generateJwt(user);
-		String cookie = cookieUtil.createCookie("access_token", tokenDto.accessToken(), "localhost").toString();
-		response.addHeader("Set-Cookie", cookie);
-
-		cookie = cookieUtil.createCookie("refresh_token", tokenDto.refreshToken(), "localhost").toString();
-		response.addHeader("Set-Cookie", cookie);
+		setCookies(response, "access_token", tokenDto.accessToken());
+		setCookies(response, "refresh_token", tokenDto.refreshToken());
 
 		response.sendRedirect(redirectUrl);
+	}
+
+	private void setCookies(HttpServletResponse response, String tokenName, String tokenValue) {
+		String cookie = cookieUtil.createCookie(tokenName, tokenValue, "localhost").toString();
+		response.addHeader("Set-Cookie", cookie);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/auth/oauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/site/sonisori/sonisori/auth/oauth2/CustomOAuth2SuccessHandler.java
@@ -34,13 +34,13 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 		User user = customUserDetails.getUser();
 
 		TokenDto tokenDto = jwtUtil.generateJwt(user);
-		setCookies(response, "access_token", tokenDto.accessToken());
-		setCookies(response, "refresh_token", tokenDto.refreshToken());
+		addCookies(response, "access_token", tokenDto.accessToken());
+		addCookies(response, "refresh_token", tokenDto.refreshToken());
 
 		response.sendRedirect(redirectUrl);
 	}
 
-	private void setCookies(HttpServletResponse response, String tokenName, String tokenValue) {
+	private void addCookies(HttpServletResponse response, String tokenName, String tokenValue) {
 		String cookie = cookieUtil.createCookie(tokenName, tokenValue, "localhost").toString();
 		response.addHeader("Set-Cookie", cookie);
 	}

--- a/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
+++ b/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
@@ -13,7 +13,8 @@ public enum ErrorMessage {
 	INVALID_TOKEN("유효하지 않은 토큰입니다."),
 	METHOD_VALIDATION_FAILED("메서드 유효성 검사에 실패했습니다."),
 	NULL_POINTER_EXCEPTION("서버에서 null 참조 오류가 발생했습니다."),
-	DUPLICATE_EMAIL("이미 사용 중인 이메일입니다.");
+	DUPLICATE_EMAIL("이미 사용 중인 이메일입니다."),
+	INVALID_USER("회원 정보가 잘못되었습니다.");
 
 	public static final String INVALID_VALUE = "형식에 올바르게 작성해주세요.";
 

--- a/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
+++ b/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
 			)
 			.authorizeHttpRequests((auth) ->
 				auth
-					.requestMatchers("/login/oauth2/code/*", "/api/auth/signup").permitAll()
+					.requestMatchers("/login/oauth2/code/*", "/api/auth/signup", "/api/auth/login").permitAll()
 					.anyRequest().authenticated()
 			)
 			.exceptionHandling(exceptionHandlerConfig)

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -38,13 +38,13 @@ public class UserController {
 		User user = userService.validateUser(loginRequest);
 		TokenDto tokenDto = userService.createJwt(user);
 
-		setCookies(response, "access_token", tokenDto.accessToken());
-		setCookies(response, "refresh_token", tokenDto.refreshToken());
+		addCookies(response, "access_token", tokenDto.accessToken());
+		addCookies(response, "refresh_token", tokenDto.refreshToken());
 
 		return ResponseEntity.noContent().build();
 	}
 
-	private void setCookies(HttpServletResponse response, String tokenName, String tokenValue) {
+	private void addCookies(HttpServletResponse response, String tokenName, String tokenValue) {
 		String cookie = cookieUtil.createCookie(tokenName, tokenValue, "localhost").toString();
 		response.addHeader("Set-Cookie", cookie);
 	}

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -41,7 +41,7 @@ public class UserController {
 		setCookies(response, "access_token", tokenDto.accessToken());
 		setCookies(response, "refresh_token", tokenDto.refreshToken());
 
-		return ResponseEntity.ok().build();
+		return ResponseEntity.noContent().build();
 	}
 
 	private void setCookies(HttpServletResponse response, String tokenName, String tokenValue) {

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -7,9 +7,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.auth.cookie.CookieUtil;
+import site.sonisori.sonisori.auth.jwt.dto.TokenDto;
+import site.sonisori.sonisori.dto.user.LoginRequest;
 import site.sonisori.sonisori.dto.user.SignUpRequest;
+import site.sonisori.sonisori.entity.User;
 import site.sonisori.sonisori.service.UserService;
 
 @RestController
@@ -17,10 +22,30 @@ import site.sonisori.sonisori.service.UserService;
 @RequiredArgsConstructor
 public class UserController {
 	private final UserService userService;
+	private final CookieUtil cookieUtil;
 
 	@PostMapping("/auth/signup")
 	public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
 		userService.signUp(signUpRequest);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@PostMapping("/auth/login")
+	public ResponseEntity<Void> login(
+		@RequestBody @Valid LoginRequest loginRequest,
+		HttpServletResponse response
+	) {
+		User user = userService.validateUser(loginRequest);
+		TokenDto tokenDto = userService.createJwt(user);
+
+		setCookies(response, "access_token", tokenDto.accessToken());
+		setCookies(response, "refresh_token", tokenDto.refreshToken());
+
+		return ResponseEntity.ok().build();
+	}
+
+	private void setCookies(HttpServletResponse response, String tokenName, String tokenValue) {
+		String cookie = cookieUtil.createCookie(tokenName, tokenValue, "localhost").toString();
+		response.addHeader("Set-Cookie", cookie);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/dto/user/LoginRequest.java
+++ b/src/main/java/site/sonisori/sonisori/dto/user/LoginRequest.java
@@ -1,0 +1,14 @@
+package site.sonisori.sonisori.dto.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
+
+public record LoginRequest(
+	@Email(message = ErrorMessage.INVALID_VALUE)
+	String email,
+
+	@NotBlank(message = ErrorMessage.INVALID_VALUE)
+	String password
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -45,6 +46,12 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(new ErrorResponse(errorMessage));
+	}
+
+	@ExceptionHandler(AuthenticationException.class)
+	public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException ex) {
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+			.body(new ErrorResponse(ex.getMessage()));
 	}
 
 	@ExceptionHandler(AlreadyExistException.class)

--- a/src/main/java/site/sonisori/sonisori/exception/InvalidUserException.java
+++ b/src/main/java/site/sonisori/sonisori/exception/InvalidUserException.java
@@ -1,0 +1,11 @@
+package site.sonisori.sonisori.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+import site.sonisori.sonisori.common.constants.ErrorMessage;
+
+public class InvalidUserException extends AuthenticationException {
+	public InvalidUserException() {
+		super(ErrorMessage.INVALID_USER.getMessage());
+	}
+}

--- a/src/main/java/site/sonisori/sonisori/repository/UserRepository.java
+++ b/src/main/java/site/sonisori/sonisori/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByUsername(String username);
 
 	boolean existsByEmail(String email);
+
+	Optional<User> findByEmail(String email);
 }

--- a/src/main/java/site/sonisori/sonisori/service/UserService.java
+++ b/src/main/java/site/sonisori/sonisori/service/UserService.java
@@ -4,12 +4,16 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.auth.jwt.JwtUtil;
+import site.sonisori.sonisori.auth.jwt.dto.TokenDto;
 import site.sonisori.sonisori.common.constants.ErrorMessage;
 import site.sonisori.sonisori.common.enums.Role;
 import site.sonisori.sonisori.common.enums.SocialType;
+import site.sonisori.sonisori.dto.user.LoginRequest;
 import site.sonisori.sonisori.dto.user.SignUpRequest;
 import site.sonisori.sonisori.entity.User;
 import site.sonisori.sonisori.exception.AlreadyExistException;
+import site.sonisori.sonisori.exception.InvalidUserException;
 import site.sonisori.sonisori.repository.UserRepository;
 
 @Service
@@ -17,11 +21,27 @@ import site.sonisori.sonisori.repository.UserRepository;
 public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final JwtUtil jwtUtil;
 
 	public void signUp(SignUpRequest signUpRequest) {
 		checkEmailDuplicate(signUpRequest.email());
 		User user = buildUserForSignUp(signUpRequest);
 		userRepository.save(user);
+	}
+
+	public User validateUser(LoginRequest loginRequest) {
+		String email = loginRequest.email();
+		String password = loginRequest.password();
+		User user = userRepository.findByEmail(email).orElseThrow(InvalidUserException::new);
+
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw new InvalidUserException();
+		}
+		return user;
+	}
+
+	public TokenDto createJwt(User user) {
+		return jwtUtil.generateJwt(user);
 	}
 
 	private void checkEmailDuplicate(String email) {


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 자체 로그인 api를 구현하였습니다. 

### PR Point
- 로그인 성공시 쿠키가 생성되고 redis에 refresh token이 저장되는 것을 확인했습니다.
- 회원 정보가 올바르지 않을 경우에 대한 에러 처리를 진행하였습니다. 

### 📸 스크린샷

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/cc1c3cb0-c09d-47b7-905b-f0ed320fb960) | 회원 정보 틀릴 경우|
|![image](https://github.com/user-attachments/assets/1f459eab-d176-4671-8d4c-100997c9fe71)| 로그인 성공 |
|![image](https://github.com/user-attachments/assets/a922b029-35ae-4ed3-aea5-489c459df96c)| 로그인 성공 시 쿠키 생성 |
|![image](https://github.com/user-attachments/assets/e75ae806-6391-46ab-81e9-3092d0125503)| redis에 refresh token 저장됨|

closed #28 