### PR TITLE
feat: 사용자 인증 상태 조회 API 구현 

### DIFF
--- a/src/main/java/site/sonisori/sonisori/auth/CustomUserDetails.java
+++ b/src/main/java/site/sonisori/sonisori/auth/CustomUserDetails.java
@@ -1,4 +1,4 @@
-package site.sonisori.sonisori.auth.oauth2;
+package site.sonisori.sonisori.auth;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -16,7 +16,7 @@ import site.sonisori.sonisori.common.enums.Role;
 import site.sonisori.sonisori.entity.User;
 
 @RequiredArgsConstructor
-public class CustomOAuth2User implements OAuth2User, UserDetails {
+public class CustomUserDetails implements OAuth2User, UserDetails {
 	private final OAuth2UserDto oAuth2UserDto;
 	@Getter
 	private final User user;

--- a/src/main/java/site/sonisori/sonisori/auth/oauth2/CustomOAuth2Service.java
+++ b/src/main/java/site/sonisori/sonisori/auth/oauth2/CustomOAuth2Service.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.auth.CustomUserDetails;
 import site.sonisori.sonisori.auth.oauth2.dto.KakaoResponse;
 import site.sonisori.sonisori.auth.oauth2.dto.NaverResponse;
 import site.sonisori.sonisori.auth.oauth2.dto.OAuth2Response;
@@ -55,7 +56,7 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService implements Use
 
 		User user = getUserOrRegister(oAuth2Response, username);
 
-		return new CustomOAuth2User(oAuth2UserDto, user);
+		return new CustomUserDetails(oAuth2UserDto, user);
 	}
 
 	@Override
@@ -71,7 +72,7 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService implements Use
 			user.getSocialType()
 		);
 
-		return new CustomOAuth2User(userDto, user);
+		return new CustomUserDetails(userDto, user);
 	}
 
 	private OAuth2Response getOAuth2Response(String registrationId, OAuth2User oAuth2User) {

--- a/src/main/java/site/sonisori/sonisori/auth/oauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/site/sonisori/sonisori/auth/oauth2/CustomOAuth2SuccessHandler.java
@@ -11,6 +11,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.auth.CustomUserDetails;
 import site.sonisori.sonisori.auth.cookie.CookieUtil;
 import site.sonisori.sonisori.auth.jwt.JwtUtil;
 import site.sonisori.sonisori.auth.jwt.dto.TokenDto;
@@ -30,7 +31,7 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
 
-		CustomOAuth2User customUserDetails = (CustomOAuth2User)authentication.getPrincipal();
+		CustomUserDetails customUserDetails = (CustomUserDetails)authentication.getPrincipal();
 		User user = customUserDetails.getUser();
 
 		TokenDto tokenDto = jwtUtil.generateJwt(user);

--- a/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
+++ b/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
@@ -50,7 +50,9 @@ public class SecurityConfig {
 			)
 			.authorizeHttpRequests((auth) ->
 				auth
-					.requestMatchers("/login/oauth2/code/*", "/api/auth/signup", "/api/auth/login", "/api/auth").permitAll()
+					.requestMatchers(
+						"/login/oauth2/code/*", "/api/auth/signup", "/api/auth/login", "/api/auth"
+					).permitAll()
 					.anyRequest().authenticated()
 			)
 			.exceptionHandling(exceptionHandlerConfig)

--- a/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
+++ b/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
 			)
 			.authorizeHttpRequests((auth) ->
 				auth
-					.requestMatchers("/login/oauth2/code/*", "/api/auth/signup", "/api/auth/login").permitAll()
+					.requestMatchers("/login/oauth2/code/*", "/api/auth/signup", "/api/auth/login", "/api/auth").permitAll()
 					.anyRequest().authenticated()
 			)
 			.exceptionHandling(exceptionHandlerConfig)

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -51,11 +51,11 @@ public class UserController {
 	}
 
 	@GetMapping("/auth")
-	public ResponseEntity<AuthResponse> authenticate(
+	public ResponseEntity<AuthResponse> getUserAuthStatus(
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
 		Optional<User> user = Optional.ofNullable(userDetails).map(CustomUserDetails::getUser);
-		AuthResponse authResponse = userService.getUserAuthStatus(user);
+		AuthResponse authResponse = userService.createAuthResponse(user);
 		return ResponseEntity.ok(authResponse);
 	}
 

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -1,7 +1,11 @@
 package site.sonisori.sonisori.controller;
 
+import java.util.Optional;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,8 +14,10 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.auth.CustomUserDetails;
 import site.sonisori.sonisori.auth.cookie.CookieUtil;
 import site.sonisori.sonisori.auth.jwt.dto.TokenDto;
+import site.sonisori.sonisori.dto.user.AuthResponse;
 import site.sonisori.sonisori.dto.user.LoginRequest;
 import site.sonisori.sonisori.dto.user.SignUpRequest;
 import site.sonisori.sonisori.entity.User;
@@ -42,6 +48,15 @@ public class UserController {
 		addCookies(response, "refresh_token", tokenDto.refreshToken());
 
 		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/auth")
+	public ResponseEntity<AuthResponse> authenticate(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		Optional<User> user = Optional.ofNullable(userDetails).map(CustomUserDetails::getUser);
+		AuthResponse authResponse = userService.getUserAuthStatus(user);
+		return ResponseEntity.ok(authResponse);
 	}
 
 	private void addCookies(HttpServletResponse response, String tokenName, String tokenValue) {

--- a/src/main/java/site/sonisori/sonisori/dto/user/AuthResponse.java
+++ b/src/main/java/site/sonisori/sonisori/dto/user/AuthResponse.java
@@ -1,0 +1,10 @@
+package site.sonisori.sonisori.dto.user;
+
+import lombok.Builder;
+
+@Builder
+public record AuthResponse(
+	boolean isLogin,
+	String name
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/service/UserService.java
+++ b/src/main/java/site/sonisori/sonisori/service/UserService.java
@@ -66,15 +66,12 @@ public class UserService {
 	}
 
 	@Transactional(readOnly = true)
-	public AuthResponse getUserAuthStatus(Optional<User> user) {
-		if (user.isPresent()) {
-			return getLoggedInUserAuthStatus(user.get());
-		} else {
-			return getAnonymousUserAuthStatus();
-		}
+	public AuthResponse createAuthResponse(Optional<User> user) {
+		return (user.isPresent())
+			? createLoggedInUserAuthStatus(user.get()) : createAnonymousUserAuthStatus();
 	}
 
-	private AuthResponse getLoggedInUserAuthStatus(User user) {
+	private AuthResponse createLoggedInUserAuthStatus(User user) {
 		String name = user.getName();
 		return AuthResponse.builder()
 			.isLogin(true)
@@ -82,7 +79,7 @@ public class UserService {
 			.build();
 	}
 
-	private AuthResponse getAnonymousUserAuthStatus() {
+	private AuthResponse createAnonymousUserAuthStatus() {
 		return AuthResponse.builder()
 			.isLogin(false)
 			.name(null)


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 사용자 인증 상태를 조회하는 API (`/auth`)를 구현했습니다.
- 로그인한 사용자와 비로그인 사용자의 인증 상태를 구분하여 응답하는 기능을 추가했습니다.
- AuthResponse 레코드 클래스를 사용하여 응답 데이터를 구조화했습니다.

### 📸 스크린샷

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/8c90062c-0d2d-4626-a89b-a5feee6c6631)| 로그인 시 |
|![image](https://github.com/user-attachments/assets/15e4fe98-6e6e-49ba-a18b-4d9a1d5550ed)| 비 로그인 시 |


closed #31 