### PR TITLE
feat: 로그아웃 api 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/auth/jwt/JwtUtil.java
+++ b/src/main/java/site/sonisori/sonisori/auth/jwt/JwtUtil.java
@@ -74,6 +74,13 @@ public class JwtUtil {
 		return refreshToken.getRefreshToken();
 	}
 
+	public void deleteRefreshToken(Long userId, String refreshToken) {
+		RefreshToken token = refreshTokenRepository.findByUserIdAndRefreshToken(userId, refreshToken)
+			.orElseThrow(() -> new JwtException(ErrorMessage.NOT_FOUND_TOKEN.toString()));
+
+		refreshTokenRepository.delete(token);
+	}
+
 	public TokenDto generateJwt(User user) {
 		String accessToken = createAccessToken(user);
 		String refreshToken = createRefreshToken(user);

--- a/src/main/java/site/sonisori/sonisori/auth/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/site/sonisori/sonisori/auth/jwt/repository/RefreshTokenRepository.java
@@ -1,5 +1,7 @@
 package site.sonisori.sonisori.auth.jwt.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import site.sonisori.sonisori.auth.jwt.entity.RefreshToken;
 
 @Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+	Optional<RefreshToken> findByUserIdAndRefreshToken(Long userId, String refreshToken);
 }

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -41,14 +41,16 @@ public class UserController {
 		String refreshToken = cookieUtil.getCookieValue(request, "refresh_token");
 		jwtUtil.deleteRefreshToken(userId, refreshToken);
 
-		String cookie = cookieUtil.clearCookie("access_token", "localhost").toString();
-		response.addHeader("Set-Cookie", cookie);
-
-		cookie = cookieUtil.clearCookie("refresh_token", "localhost").toString();
-		response.addHeader("Set-Cookie", cookie);
+		clearCookies(response, "access_token");
+		clearCookies(response, "refresh_token");
 
 		SecurityContextHolder.clearContext();
 
 		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
+	public void clearCookies(HttpServletResponse response, String cookieName) {
+		String cookie = cookieUtil.clearCookie(cookieName, "localhost").toString();
+		response.addHeader("Set-Cookie", cookie);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -2,13 +2,21 @@ package site.sonisori.sonisori.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.auth.cookie.CookieUtil;
+import site.sonisori.sonisori.auth.jwt.JwtUtil;
+import site.sonisori.sonisori.auth.oauth2.CustomOAuth2User;
 import site.sonisori.sonisori.dto.user.SignUpRequest;
 import site.sonisori.sonisori.service.UserService;
 
@@ -17,10 +25,30 @@ import site.sonisori.sonisori.service.UserService;
 @RequiredArgsConstructor
 public class UserController {
 	private final UserService userService;
+	private final CookieUtil cookieUtil;
+	private final JwtUtil jwtUtil;
 
 	@PostMapping("/auth/signup")
 	public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
 		userService.signUp(signUpRequest);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@DeleteMapping("/logout")
+	public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+		HttpServletRequest request, HttpServletResponse response) {
+		Long userId = customOAuth2User.getUserId();
+		String refreshToken = cookieUtil.getCookieValue(request, "refresh_token");
+		jwtUtil.deleteRefreshToken(userId, refreshToken);
+
+		String cookie = cookieUtil.clearCookie("access_token", "localhost").toString();
+		response.addHeader("Set-Cookie", cookie);
+
+		cookie = cookieUtil.clearCookie("refresh_token", "localhost").toString();
+		response.addHeader("Set-Cookie", cookie);
+
+		SecurityContextHolder.clearContext();
+
+		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 로그아웃 api를 구현하였습니다.
(로그아웃시  refresh token 을 DB에서 삭제하도록 구현했습니다.)

### 논의 사항 (선택)
- controller 작성하는 과정에서 이전 PR에서 setCookies로 메서드 분리하신걸 보고 저도 메서드 분리해봤습니다..
- 네이버의 경우 로그아웃 시에 따로 api 규칙을 정해놓은 것이 없으나 카카오는 있어서 찾아보니 카카오는 카카오쪽 서버에 api를 호출하여 카카오서버에서 가지고 있는 토큰과 세션을 만료시키도록 안내를 해놓았습니다. 왜 그런가보니 여러 기기에서 로그인했을때 하나만 로그아웃이 되고 다른 기기는 여전히 로그인되어 있는 것을 방지하려고 하는 것 같습니다. 그런데 이 부분은 크게 상관없을 것 같아서 굳이 카카오서버 api는 호출하지 않았습니다. (제가 잘 이해한건지는 모르겠습니다..)


closed #29 