### PR TITLE
feat: 수어 퀴즈 토픽 리스트 조회 api 구현 

### DIFF
--- a/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
@@ -21,11 +21,11 @@ public class SignTopicController {
 	private final SignTopicService signTopicService;
 
 	@GetMapping("/topics")
-	public ResponseEntity<List<SignTopicResponse>> getTopicsWithUserStatus(
+	public ResponseEntity<List<SignTopicResponse>> getAllTopicsWithUserProgress(
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
 		Long userId = userDetails.getUserId();
-		List<SignTopicResponse> topics = signTopicService.getTopicsWithStatus(userId);
+		List<SignTopicResponse> topics = signTopicService.fetchTopicsWithQuizProgress(userId);
 		return ResponseEntity.ok(topics);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
@@ -1,0 +1,31 @@
+package site.sonisori.sonisori.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.auth.CustomUserDetails;
+import site.sonisori.sonisori.dto.signtopic.SignTopicResponse;
+import site.sonisori.sonisori.service.SignTopicService;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SignTopicController {
+
+	private final SignTopicService signTopicService;
+
+	@GetMapping("/topics")
+	public ResponseEntity<List<SignTopicResponse>> getTopicsWithUserStatus(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		Long userId = userDetails.getUserId();
+		List<SignTopicResponse> topics = signTopicService.getTopicsWithStatus(userId);
+		return ResponseEntity.ok(topics);
+	}
+}

--- a/src/main/java/site/sonisori/sonisori/dto/signtopic/SignTopicResponse.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signtopic/SignTopicResponse.java
@@ -11,6 +11,6 @@ public record SignTopicResponse(
 	Difficulty difficulty,
 	boolean isCompleted,
 	int totalQuizzes,
-	int count
+	int correctCount
 ) {
 }

--- a/src/main/java/site/sonisori/sonisori/dto/signtopic/SignTopicResponse.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signtopic/SignTopicResponse.java
@@ -8,6 +8,9 @@ public record SignTopicResponse(
 	Long id,
 	String title,
 	String contents,
-	Difficulty difficulty
+	Difficulty difficulty,
+	boolean isCompleted,
+	int totalQuizzes,
+	int count
 ) {
 }

--- a/src/main/java/site/sonisori/sonisori/dto/signtopic/SignTopicResponse.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signtopic/SignTopicResponse.java
@@ -1,0 +1,13 @@
+package site.sonisori.sonisori.dto.signtopic;
+
+import lombok.Builder;
+import site.sonisori.sonisori.common.enums.Difficulty;
+
+@Builder
+public record SignTopicResponse(
+	Long id,
+	String title,
+	String contents,
+	Difficulty difficulty
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/entity/QuizHistory.java
+++ b/src/main/java/site/sonisori/sonisori/entity/QuizHistory.java
@@ -41,7 +41,7 @@ public class QuizHistory extends DateEntity {
 	private SignTopic signTopic;
 
 	@NotNull
-	@Column(name = "count")
+	@Column(name = "correct_count")
 	@Min(0)
-	private int count;
+	private int correctCount;
 }

--- a/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
+++ b/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -43,6 +44,11 @@ public class SignTopic extends DateEntity {
 	@NotBlank
 	@Size(max = 255)
 	private String contents;
+
+	@Column(name = "total_quizzes")
+	@NotNull
+	@Min(0)
+	private int totalQuizzes;
 
 	@Column(name = "difficulty")
 	@NotNull

--- a/src/main/java/site/sonisori/sonisori/repository/QuizHistoryRepository.java
+++ b/src/main/java/site/sonisori/sonisori/repository/QuizHistoryRepository.java
@@ -1,8 +1,11 @@
 package site.sonisori.sonisori.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import site.sonisori.sonisori.entity.QuizHistory;
 
 public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
+	List<QuizHistory> findByUser_id(Long userId);
 }

--- a/src/main/java/site/sonisori/sonisori/repository/QuizHistoryRepository.java
+++ b/src/main/java/site/sonisori/sonisori/repository/QuizHistoryRepository.java
@@ -1,0 +1,8 @@
+package site.sonisori.sonisori.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import site.sonisori.sonisori.entity.QuizHistory;
+
+public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
+}

--- a/src/main/java/site/sonisori/sonisori/repository/SignQuizRepository.java
+++ b/src/main/java/site/sonisori/sonisori/repository/SignQuizRepository.java
@@ -1,0 +1,9 @@
+package site.sonisori.sonisori.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import site.sonisori.sonisori.entity.SignQuiz;
+
+public interface SignQuizRepository extends JpaRepository<SignQuiz, Long> {
+	int countBySignTopic_id(Long signTopicId);
+}

--- a/src/main/java/site/sonisori/sonisori/repository/SignQuizRepository.java
+++ b/src/main/java/site/sonisori/sonisori/repository/SignQuizRepository.java
@@ -1,9 +1,0 @@
-package site.sonisori.sonisori.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import site.sonisori.sonisori.entity.SignQuiz;
-
-public interface SignQuizRepository extends JpaRepository<SignQuiz, Long> {
-	int countBySignTopic_id(Long signTopicId);
-}

--- a/src/main/java/site/sonisori/sonisori/repository/SignTopicRepository.java
+++ b/src/main/java/site/sonisori/sonisori/repository/SignTopicRepository.java
@@ -1,0 +1,10 @@
+package site.sonisori.sonisori.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import site.sonisori.sonisori.entity.SignTopic;
+
+@Repository
+public interface SignTopicRepository extends JpaRepository<SignTopic, Long> {
+}

--- a/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
@@ -1,0 +1,48 @@
+package site.sonisori.sonisori.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.dto.signtopic.SignTopicResponse;
+import site.sonisori.sonisori.entity.QuizHistory;
+import site.sonisori.sonisori.entity.SignTopic;
+import site.sonisori.sonisori.repository.QuizHistoryRepository;
+import site.sonisori.sonisori.repository.SignQuizRepository;
+import site.sonisori.sonisori.repository.SignTopicRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SignTopicService {
+	private final SignTopicRepository signTopicRepository;
+	private final QuizHistoryRepository quizHistoryRepository;
+	private final SignQuizRepository signQuizRepository;
+
+	public List<SignTopicResponse> getTopicsWithStatus(Long userId) {
+		List<SignTopic> signTopics = signTopicRepository.findAll();
+		List<QuizHistory> quizHistories = quizHistoryRepository.findByUser_id(userId);
+
+		return signTopics.stream().map(
+			signTopic -> {
+				QuizHistory quizHistory = quizHistories.stream()
+					.filter(history -> history.getSignTopic().getId().equals(signTopic.getId()))
+					.findFirst()
+					.orElse(null);
+
+				int totalQuizzes = signQuizRepository.countBySignTopic_id(signTopic.getId());
+				int count = (quizHistory != null) ? quizHistory.getCount() : 0;
+
+				return SignTopicResponse.builder()
+					.id(signTopic.getId())
+					.title(signTopic.getTitle())
+					.contents(signTopic.getContents())
+					.difficulty(signTopic.getDifficulty())
+					.isCompleted(quizHistory != null)
+					.totalQuizzes(totalQuizzes)
+					.count(count)
+					.build();
+			}).collect(Collectors.toList());
+	}
+}

--- a/src/main/resources/db/migration/V3__modify_quiz_table.sql
+++ b/src/main/resources/db/migration/V3__modify_quiz_table.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `sonisori`.`sign_topics`
+    ADD COLUMN `total_quizzes` INT NOT NULL DEFAULT 0 AFTER `contents`;
+
+ALTER TABLE `sonisori`.`quiz_histories`
+    CHANGE COLUMN `count` `correct_count` INT(11) NOT NULL DEFAULT 0 ;


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 사용자가 토픽 리스트와 각 토픽별 퀴즈 진행 상태를 확인할 수 있도록 API 구현하였습니다.
- 사용자 퀴즈 기록과 토픽 데이터를 매핑하여 응답을 생성하였습니다.
  - 사용자가 해당 토픽을 완료하였는지를 알 수 있는 `isCompleted`
  - 전체 퀴즈 수 
  - 사용자가 맞힌 퀴즈 수

### PR Point
- `SignTopic` 엔티티에 해당 토픽에서의 전체 퀴즈 수인 `totalQuizzes`를 추가하였습니다.
  - 원래는 전체 퀴즈 수를 API 호출 시마다 `countBySignTopic_id`를 통해 계산하려고 했습니다.
  - 하지만 이는 데이터베이스에 불필요한 부하를 줄 가능성이 있다고 판단하여, 전체 퀴즈 수를 SignTopic 엔티티 필드로 추가하고 퀴즈를 추가/삭제할 때 해당 값을 갱신하는 방식으로 변경했습니다.
  - 따라서 이에 따라 db를 변경하였습니다.
- 정확성을 높이기 위해 `correct_count`로 필드 명을 수정하였습니다.

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/05769d92-53a9-4a07-b9ae-ac46e5ec780d)|api 호출 시 |

### 논의 사항 (선택)
- 논의할 사항이 있다면 적어주세요.

closed #34 