### PR TITLE
feat: 수어 퀴즈 목록 조회 api 구현 

### DIFF
--- a/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
+++ b/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
@@ -14,7 +14,8 @@ public enum ErrorMessage {
 	METHOD_VALIDATION_FAILED("메서드 유효성 검사에 실패했습니다."),
 	NULL_POINTER_EXCEPTION("서버에서 null 참조 오류가 발생했습니다."),
 	DUPLICATE_EMAIL("이미 사용 중인 이메일입니다."),
-	INVALID_USER("회원 정보가 잘못되었습니다.");
+	INVALID_USER("회원 정보가 잘못되었습니다."),
+	NOT_FOUND_TOPIC("존재하지 않는 토픽입니다.");
 
 	public static final String INVALID_VALUE = "형식에 올바르게 작성해주세요.";
 

--- a/src/main/java/site/sonisori/sonisori/controller/SignQuizController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignQuizController.java
@@ -1,0 +1,29 @@
+package site.sonisori.sonisori.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.dto.signquiz.SignQuizResponse;
+import site.sonisori.sonisori.service.SignQuizService;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SignQuizController {
+
+	private final SignQuizService signQuizService;
+
+	@GetMapping("/topics/{topicId}/quizzes")
+	public ResponseEntity<List<SignQuizResponse>> getQuizzesByTopicId(
+		@PathVariable(name = "topicId") Long signTopicId
+	) {
+		List<SignQuizResponse> signQuizzes = signQuizService.findQuizzesByTopicId(signTopicId);
+		return ResponseEntity.ok(signQuizzes);
+	}
+}

--- a/src/main/java/site/sonisori/sonisori/dto/signquiz/SignQuizResponse.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signquiz/SignQuizResponse.java
@@ -1,0 +1,10 @@
+package site.sonisori.sonisori.dto.signquiz;
+
+import lombok.Builder;
+
+@Builder
+public record SignQuizResponse(
+	Long quizId,
+	String sentence
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/dto/signquiz/SignQuizResponse.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signquiz/SignQuizResponse.java
@@ -1,8 +1,5 @@
 package site.sonisori.sonisori.dto.signquiz;
 
-import lombok.Builder;
-
-@Builder
 public record SignQuizResponse(
 	Long quizId,
 	String sentence

--- a/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
@@ -48,6 +48,12 @@ public class GlobalExceptionHandler {
 			.body(new ErrorResponse(errorMessage));
 	}
 
+	@ExceptionHandler(NotFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+			.body(new ErrorResponse(ex.getMessage()));
+	}
+
 	@ExceptionHandler(AuthenticationException.class)
 	public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException ex) {
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/src/main/java/site/sonisori/sonisori/exception/NotFoundException.java
+++ b/src/main/java/site/sonisori/sonisori/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package site.sonisori.sonisori.exception;
+
+public class NotFoundException extends RuntimeException {
+	public NotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/site/sonisori/sonisori/repository/SignQuizRepository.java
+++ b/src/main/java/site/sonisori/sonisori/repository/SignQuizRepository.java
@@ -1,5 +1,7 @@
 package site.sonisori.sonisori.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import site.sonisori.sonisori.entity.SignQuiz;
 
 @Repository
 public interface SignQuizRepository extends JpaRepository<SignQuiz, Long> {
+	List<SignQuiz> findAllBySignTopic_id(Long topicId);
 }

--- a/src/main/java/site/sonisori/sonisori/repository/SignQuizRepository.java
+++ b/src/main/java/site/sonisori/sonisori/repository/SignQuizRepository.java
@@ -1,0 +1,10 @@
+package site.sonisori.sonisori.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import site.sonisori.sonisori.entity.SignQuiz;
+
+@Repository
+public interface SignQuizRepository extends JpaRepository<SignQuiz, Long> {
+}

--- a/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
@@ -20,7 +20,7 @@ public class SignQuizService {
 	private final SignQuizRepository signQuizRepository;
 	private final SignTopicRepository signTopicRepository;
 
-	public List<SignQuizResponse> getSignQuizzes(
+	public List<SignQuizResponse> findQuizzesByTopicId(
 		Long signTopicId
 	) {
 		SignTopic signTopic = signTopicRepository.findById(signTopicId)

--- a/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
@@ -1,0 +1,36 @@
+package site.sonisori.sonisori.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
+import site.sonisori.sonisori.dto.signquiz.SignQuizResponse;
+import site.sonisori.sonisori.entity.SignQuiz;
+import site.sonisori.sonisori.entity.SignTopic;
+import site.sonisori.sonisori.exception.NotFoundException;
+import site.sonisori.sonisori.repository.SignQuizRepository;
+import site.sonisori.sonisori.repository.SignTopicRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SignQuizService {
+	private final SignQuizRepository signQuizRepository;
+	private final SignTopicRepository signTopicRepository;
+
+	public List<SignQuizResponse> getSignQuizzes(
+		Long signTopicId
+	) {
+		SignTopic signTopic = signTopicRepository.findById(signTopicId)
+			.orElseThrow(()-> new NotFoundException(ErrorMessage.NOT_FOUND_TOPIC.getMessage()));
+		List<SignQuiz> signQuizzes = signQuizRepository.findAllBySignTopic_id(signTopicId);
+
+		return signQuizzes.stream()
+			.map(quiz -> new SignQuizResponse(
+				quiz.getId(), quiz.getSentence()
+			))
+			.collect(Collectors.toList());
+	}
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 특정 토픽에 대한 퀴즈 목록을 조회하는 API를 구현했습니다.
- 존재하지 않는 topic id에 대한 에러 처리를 진행하였습니다. 


### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/2f548c5a-6e73-442c-9e4d-8d2a296da098) | 존재하는 topic에 대한 퀴즈 |
|![image](https://github.com/user-attachments/assets/f00e10e4-ec2c-40ea-8bdd-777a855fdcfd)|존재하지 않는 topic의 경우|


closed #37 