### PR TITLE
feat: 회원탈퇴 api 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
+++ b/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
@@ -15,6 +15,7 @@ public enum ErrorMessage {
 	NULL_POINTER_EXCEPTION("서버에서 null 참조 오류가 발생했습니다."),
 	DUPLICATE_EMAIL("이미 사용 중인 이메일입니다."),
 	INVALID_USER("회원 정보가 잘못되었습니다."),
+	NOT_FOUND_USER("존재하지 않는 회원입니다."),
 	NOT_FOUND_TOPIC("존재하지 않는 토픽입니다.");
 
 	public static final String INVALID_VALUE = "형식에 올바르게 작성해주세요.";

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -78,6 +78,23 @@ public class UserController {
 		return ResponseEntity.ok(authResponse);
 	}
 
+	@DeleteMapping("/users/me")
+	public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		HttpServletRequest request, HttpServletResponse response) {
+		Long userId = customUserDetails.getUserId();
+		userService.deleteUser(userId);
+
+		String refreshToken = cookieUtil.getCookieValue(request, "refresh_token");
+		jwtUtil.deleteRefreshToken(refreshToken);
+
+		deleteCookies(response, "access_token");
+		deleteCookies(response, "refresh_token");
+
+		SecurityContextHolder.clearContext();
+
+		return ResponseEntity.noContent().build();
+	}
+
 	private void addCookies(HttpServletResponse response, String tokenName, String tokenValue) {
 		String cookie = cookieUtil.createCookie(tokenName, tokenValue, "localhost").toString();
 		response.addHeader("Set-Cookie", cookie);

--- a/src/main/java/site/sonisori/sonisori/service/UserService.java
+++ b/src/main/java/site/sonisori/sonisori/service/UserService.java
@@ -2,6 +2,7 @@ package site.sonisori.sonisori.service;
 
 import java.util.Optional;
 
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import site.sonisori.sonisori.dto.user.SignUpRequest;
 import site.sonisori.sonisori.entity.User;
 import site.sonisori.sonisori.exception.AlreadyExistException;
 import site.sonisori.sonisori.exception.InvalidUserException;
+import site.sonisori.sonisori.exception.NotFoundException;
 import site.sonisori.sonisori.repository.UserRepository;
 
 @Service
@@ -84,5 +86,13 @@ public class UserService {
 			.isLogin(false)
 			.name(null)
 			.build();
+	}
+
+	public void deleteUser(Long userId) {
+		try {
+			userRepository.deleteById(userId);
+		} catch (EmptyResultDataAccessException e) {
+			throw new NotFoundException(ErrorMessage.NOT_FOUND_USER.getMessage());
+		}
 	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 로그아웃과 마찬가지로 리프레쉬토큰, 쿠키를 삭제하고 추가로 DB에서 삭제하는 작업까지 추가하여 회원 탈퇴 api를 구현하였습니다.

### PR Point
- deleteUser 의 메서드 예외처리가 잘 되었는지 확인해주세요.

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/0931ca41-02d0-4bd2-9a1e-415b7dcbee23)| api호출 전 |
|![image](https://github.com/user-attachments/assets/c3b81373-f157-43b2-976e-386ce7733bb2) | api호출 성공 |
|![image](https://github.com/user-attachments/assets/abb16b55-6de7-431f-923c-6f1f25156f55)| api호출 후 db에서 삭제된 모습 |

### 논의 사항 (선택)
- 논의할 사항이 있다면 적어주세요.

closed #41 