### PR TITLE
feat: 토큰 재발급 api 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/auth/jwt/JwtUtil.java
+++ b/src/main/java/site/sonisori/sonisori/auth/jwt/JwtUtil.java
@@ -124,6 +124,19 @@ public class JwtUtil {
 		}
 	}
 
+	public boolean validateRefreshToken(String refreshToken) {
+		try {
+			UUID.fromString(refreshToken);
+
+			RefreshToken token = refreshTokenRepository.findById(refreshToken)
+				.orElseThrow(() -> new JwtException(ErrorMessage.NOT_FOUND_TOKEN.getMessage()));
+
+			return true;
+		} catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException(ErrorMessage.INVALID_TOKEN.getMessage());
+		}
+	}
+
 	public String getUsername(String token) {
 		Claims claims = extractClaims(token);
 		return claims.get("username", String.class);
@@ -141,6 +154,7 @@ public class JwtUtil {
 	}
 
 	public String reissueAccessToken(String refreshtoken) {
+		validateRefreshToken(refreshtoken);
 		Long userId = getUserId(refreshtoken);
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_USER.getMessage()));

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -87,18 +87,12 @@ public class UserController {
 		return ResponseEntity.noContent().build();
 	}
 
-	@GetMapping("/auth")
-	public ResponseEntity<AuthResponse> getUserAuthStatus(
-		@AuthenticationPrincipal CustomUserDetails userDetails
-	) {
-		Optional<User> user = Optional.ofNullable(userDetails).map(CustomUserDetails::getUser);
-		AuthResponse authResponse = userService.createAuthResponse(user);
-		return ResponseEntity.ok(authResponse);
-	}
-
 	@DeleteMapping("/users/me")
-	public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-		HttpServletRequest request, HttpServletResponse response) {
+	public ResponseEntity<Void> deleteUser(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
 		Long userId = customUserDetails.getUserId();
 		userService.deleteUser(userId);
 
@@ -109,6 +103,27 @@ public class UserController {
 		deleteCookies(response, "refresh_token");
 
 		SecurityContextHolder.clearContext();
+
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/auth")
+	public ResponseEntity<AuthResponse> getUserAuthStatus(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		Optional<User> user = Optional.ofNullable(userDetails).map(CustomUserDetails::getUser);
+		AuthResponse authResponse = userService.createAuthResponse(user);
+		return ResponseEntity.ok(authResponse);
+	}
+
+	@GetMapping("/reissue")
+	public ResponseEntity<Void> reissue(HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		String refreshToken = cookieUtil.getCookieValue(request, "refresh_token");
+
+		String newAccessToken = jwtUtil.reissueAccessToken(refreshToken);
+		addCookies(response, "access_token", newAccessToken);
 
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/site/sonisori/sonisori/controller/UserController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/UserController.java
@@ -59,10 +59,11 @@ public class UserController {
 	}
 
 	@DeleteMapping("/auth/logout")
-	public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+	public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails,
 		HttpServletRequest request, HttpServletResponse response) {
+		Long userId = userDetails.getUserId();
 		String refreshToken = cookieUtil.getCookieValue(request, "refresh_token");
-		jwtUtil.deleteRefreshToken(refreshToken);
+		jwtUtil.deleteRefreshToken(refreshToken, userId);
 
 		deleteCookies(response, "access_token");
 		deleteCookies(response, "refresh_token");
@@ -89,15 +90,15 @@ public class UserController {
 
 	@DeleteMapping("/users/me")
 	public ResponseEntity<Void> deleteUser(
-		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@AuthenticationPrincipal CustomUserDetails userDetails,
 		HttpServletRequest request,
 		HttpServletResponse response
 	) {
-		Long userId = customUserDetails.getUserId();
+		Long userId = userDetails.getUserId();
 		userService.deleteUser(userId);
 
 		String refreshToken = cookieUtil.getCookieValue(request, "refresh_token");
-		jwtUtil.deleteRefreshToken(refreshToken);
+		jwtUtil.deleteRefreshToken(refreshToken, userId);
 
 		deleteCookies(response, "access_token");
 		deleteCookies(response, "refresh_token");
@@ -117,12 +118,14 @@ public class UserController {
 	}
 
 	@GetMapping("/reissue")
-	public ResponseEntity<Void> reissue(HttpServletRequest request,
+	public ResponseEntity<Void> reissue(@AuthenticationPrincipal CustomUserDetails userDetails,
+		HttpServletRequest request,
 		HttpServletResponse response
 	) {
+		Long userId = userDetails.getUserId();
 		String refreshToken = cookieUtil.getCookieValue(request, "refresh_token");
 
-		String newAccessToken = jwtUtil.reissueAccessToken(refreshToken);
+		String newAccessToken = jwtUtil.reissueAccessToken(refreshToken, userId);
 		addCookies(response, "access_token", newAccessToken);
 
 		return ResponseEntity.noContent().build();


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- refreshToken 기반으로 accessToken 을 재발급하는 api를 구현하였습니다.

### PR Point
- accessToken 을 재발급하는 메서드인 reissueAccessToken 에서 놓친 예외처리가 있는지 확인해주세요
- 
### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/36dc9e28-bbb2-4ca1-8b0d-666eb5daf357) | 로그인시 accessToken 값 |
|![image](https://github.com/user-attachments/assets/ede08546-4427-4154-9e3e-5bef2c089437) |재발급 api 호출 후 변경된acessToken 값 |
|![image](https://github.com/user-attachments/assets/03d3d1a9-dc06-4122-b1ae-6d9c9ebaa087) | 로그인시 refeshToken 값 |
|![image](https://github.com/user-attachments/assets/b3dd6705-d806-462d-ada5-7b4d0d07f1d3) | 재발급 api호출 후에도 동일한 refreshToken 값 |

### 논의 사항 (선택)
- controller에서 addCookies 전에 deleteCookies도 호출하려 했으나 찾아본 결과 굳이 호출하지 않아도 덮어씌우기 때문에 괜찮다고 하여 addCookies만 호출했습니다.

closed #43 