### PR TITLE
feat: 관리자 토픽 추가 api구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/auth/jwt/JwtUtil.java
+++ b/src/main/java/site/sonisori/sonisori/auth/jwt/JwtUtil.java
@@ -1,7 +1,6 @@
 package site.sonisori.sonisori.auth.jwt;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 
@@ -127,7 +126,7 @@ public class JwtUtil {
 
 	public Authentication getAuthentication(String token) {
 		UserDetails userDetails = customOAuth2Service.loadUserByUsername(getUsername(token));
-		return new UsernamePasswordAuthenticationToken(userDetails, "", Collections.emptyList());
+		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
 	}
 
 }

--- a/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
+++ b/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ErrorMessage {
 	INVALID_REQUEST("유효하지 않은 요청입니다."),
 	SERVER_ERROR("서버 오류가 발생했습니다."),
+	ACCESS_DENIED("접근 권한이 없습니다."),
 	EXPIRED_TOKEN("토큰이 만료되었습니다."),
 	NOT_FOUND_TOKEN("토큰이 존재하지 않습니다."),
 	INVALID_TOKEN("유효하지 않은 토큰입니다."),

--- a/src/main/java/site/sonisori/sonisori/common/response/SuccessResponse.java
+++ b/src/main/java/site/sonisori/sonisori/common/response/SuccessResponse.java
@@ -1,0 +1,6 @@
+package site.sonisori.sonisori.common.response;
+
+public record SuccessResponse(
+	Long id
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/config/ExceptionHandlerConfig.java
+++ b/src/main/java/site/sonisori/sonisori/config/ExceptionHandlerConfig.java
@@ -49,6 +49,17 @@ public class ExceptionHandlerConfig implements Customizer<ExceptionHandlingConfi
 
 	private void handleAccessDeniedException(HttpServletRequest request, HttpServletResponse response,
 		AccessDeniedException accessDeniedException) throws IOException {
-		response.sendError(HttpServletResponse.SC_FORBIDDEN);
+		log.error("Access denied request - Method: {}, URI: {}, Error: {}",
+			request.getMethod(),
+			request.getRequestURI(),
+			accessDeniedException.getMessage());
+
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setContentType("application/json");
+
+		ErrorResponse errorResponse = new ErrorResponse(ErrorMessage.ACCESS_DENIED.getMessage()); // 메시지 수정 가능
+
+		String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+		response.getWriter().write(jsonResponse);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/config/ExceptionHandlerConfig.java
+++ b/src/main/java/site/sonisori/sonisori/config/ExceptionHandlerConfig.java
@@ -57,7 +57,7 @@ public class ExceptionHandlerConfig implements Customizer<ExceptionHandlingConfi
 		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 		response.setContentType("application/json");
 
-		ErrorResponse errorResponse = new ErrorResponse(ErrorMessage.ACCESS_DENIED.getMessage()); // 메시지 수정 가능
+		ErrorResponse errorResponse = new ErrorResponse(ErrorMessage.ACCESS_DENIED.getMessage());
 
 		String jsonResponse = objectMapper.writeValueAsString(errorResponse);
 		response.getWriter().write(jsonResponse);

--- a/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
+++ b/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
@@ -44,8 +44,8 @@ public class SecurityConfig {
 			.addFilterBefore(jwtExceptionFilter, JwtFilter.class)
 			.oauth2Login((oauth2) ->
 				oauth2.userInfoEndpoint(
-					(userInfoEndpointConfig) ->
-						userInfoEndpointConfig.userService(customOAuth2Service))
+						(userInfoEndpointConfig) ->
+							userInfoEndpointConfig.userService(customOAuth2Service))
 					.successHandler(customOAuth2SuccessHandler)
 			)
 			.authorizeHttpRequests((auth) ->
@@ -53,6 +53,7 @@ public class SecurityConfig {
 					.requestMatchers(
 						"/login/oauth2/code/*", "/api/auth/signup", "/api/auth/login", "/api/auth"
 					).permitAll()
+					.requestMatchers("/api/admin/**").hasRole("ADMIN")
 					.anyRequest().authenticated()
 			)
 			.exceptionHandling(exceptionHandlerConfig)

--- a/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
@@ -1,15 +1,21 @@
 package site.sonisori.sonisori.controller;
 
 import java.util.List;
+import java.util.Map;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.sonisori.sonisori.auth.CustomUserDetails;
+import site.sonisori.sonisori.dto.signtopic.AddSignTopicRequest;
 import site.sonisori.sonisori.dto.signtopic.SignTopicResponse;
 import site.sonisori.sonisori.service.SignTopicService;
 
@@ -27,5 +33,12 @@ public class SignTopicController {
 		Long userId = userDetails.getUserId();
 		List<SignTopicResponse> topics = signTopicService.fetchTopicsWithQuizProgress(userId);
 		return ResponseEntity.ok(topics);
+	}
+
+	@PostMapping("/admin/topics")
+	public ResponseEntity<Map<String, Long>> addSignTopic(@Valid @RequestBody AddSignTopicRequest signTopicRequest) {
+		Map<String, Long> topicId = Map.of("topicId", signTopicService.addSignTopic(signTopicRequest));
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(topicId);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
@@ -1,7 +1,6 @@
 package site.sonisori.sonisori.controller;
 
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.sonisori.sonisori.auth.CustomUserDetails;
-import site.sonisori.sonisori.dto.signtopic.AddSignTopicRequest;
+import site.sonisori.sonisori.common.response.SuccessResponse;
+import site.sonisori.sonisori.dto.signtopic.SignTopicRequest;
 import site.sonisori.sonisori.dto.signtopic.SignTopicResponse;
 import site.sonisori.sonisori.service.SignTopicService;
 
@@ -36,9 +36,8 @@ public class SignTopicController {
 	}
 
 	@PostMapping("/admin/topics")
-	public ResponseEntity<Map<String, Long>> addSignTopic(@Valid @RequestBody AddSignTopicRequest signTopicRequest) {
-		Map<String, Long> topicId = Map.of("topicId", signTopicService.addSignTopic(signTopicRequest));
-
-		return ResponseEntity.status(HttpStatus.CREATED).body(topicId);
+	public ResponseEntity<SuccessResponse> addSignTopic(@Valid @RequestBody SignTopicRequest signTopicRequest) {
+		SuccessResponse successResponse = signTopicService.addSignTopic(signTopicRequest);
+		return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/dto/signtopic/AddSignTopicRequest.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signtopic/AddSignTopicRequest.java
@@ -1,0 +1,21 @@
+package site.sonisori.sonisori.dto.signtopic;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
+import site.sonisori.sonisori.common.enums.Difficulty;
+
+public record AddSignTopicRequest(
+	@NotBlank(message = ErrorMessage.INVALID_VALUE)
+	@Size(max = 45, message = ErrorMessage.INVALID_VALUE)
+	String topicName,
+
+	@NotBlank(message = ErrorMessage.INVALID_VALUE)
+	@Size(max = 255, message = ErrorMessage.INVALID_VALUE)
+	String topicContents,
+
+	@NotNull(message = ErrorMessage.INVALID_VALUE)
+	Difficulty difficulty
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/dto/signtopic/SignTopicRequest.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signtopic/SignTopicRequest.java
@@ -6,14 +6,14 @@ import jakarta.validation.constraints.Size;
 import site.sonisori.sonisori.common.constants.ErrorMessage;
 import site.sonisori.sonisori.common.enums.Difficulty;
 
-public record AddSignTopicRequest(
+public record SignTopicRequest(
 	@NotBlank(message = ErrorMessage.INVALID_VALUE)
 	@Size(max = 45, message = ErrorMessage.INVALID_VALUE)
-	String topicName,
+	String title,
 
 	@NotBlank(message = ErrorMessage.INVALID_VALUE)
 	@Size(max = 255, message = ErrorMessage.INVALID_VALUE)
-	String topicContents,
+	String contents,
 
 	@NotNull(message = ErrorMessage.INVALID_VALUE)
 	Difficulty difficulty

--- a/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
@@ -8,7 +8,8 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
-import site.sonisori.sonisori.dto.signtopic.AddSignTopicRequest;
+import site.sonisori.sonisori.common.response.SuccessResponse;
+import site.sonisori.sonisori.dto.signtopic.SignTopicRequest;
 import site.sonisori.sonisori.dto.signtopic.SignTopicResponse;
 import site.sonisori.sonisori.entity.QuizHistory;
 import site.sonisori.sonisori.entity.SignTopic;
@@ -52,13 +53,15 @@ public class SignTopicService {
 			.build();
 	}
 
-	public Long addSignTopic(AddSignTopicRequest signTopicRequest) {
+	public SuccessResponse addSignTopic(SignTopicRequest signTopicRequest) {
 		SignTopic signTopic = SignTopic.builder()
-			.title(signTopicRequest.topicName())
-			.contents(signTopicRequest.topicContents())
+			.title(signTopicRequest.title())
+			.contents(signTopicRequest.contents())
 			.difficulty(signTopicRequest.difficulty())
 			.build();
 
-		return signTopicRepository.save(signTopic).getId();
+		Long id = signTopicRepository.save(signTopic).getId();
+
+		return new SuccessResponse(id);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.dto.signtopic.AddSignTopicRequest;
 import site.sonisori.sonisori.dto.signtopic.SignTopicResponse;
 import site.sonisori.sonisori.entity.QuizHistory;
 import site.sonisori.sonisori.entity.SignTopic;
@@ -49,5 +50,15 @@ public class SignTopicService {
 			.totalQuizzes(signTopic.getTotalQuizzes())
 			.correctCount(correctCount)
 			.build();
+	}
+
+	public Long addSignTopic(AddSignTopicRequest signTopicRequest) {
+		SignTopic signTopic = SignTopic.builder()
+			.title(signTopicRequest.topicName())
+			.contents(signTopicRequest.topicContents())
+			.difficulty(signTopicRequest.difficulty())
+			.build();
+
+		return signTopicRepository.save(signTopic).getId();
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import site.sonisori.sonisori.common.response.SuccessResponse;
@@ -53,6 +54,7 @@ public class SignTopicService {
 			.build();
 	}
 
+	@Transactional
 	public SuccessResponse addSignTopic(SignTopicRequest signTopicRequest) {
 		SignTopic signTopic = SignTopic.builder()
 			.title(signTopicRequest.title())


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 관리자 토픽 추가 api를 구현하였습니다.
- 본래 Request Body에 토픽 title과 토픽 contents 만 넘어오는 것으로 되어있었으나 difficulty도 함께 설정하는게 맞는 것 같아 difficulty도 Dto에 추가해서 구현하였습니다. (함께 설정하는게 아니라면 수정하겠습니다)

### PR Point
- 예외처리부분에서 놓친게 없나 확인해주세요
- Controller 에서 저번에 말씀해주신 데이터 가공 문제, 서비스계층 구현체의존성 문제 가 발생하지 않았는지 확인해주세요 (이 부분이 아직 헷갈려서 아마 놓친 부분이 있을 수도 있습니다ㅜ)

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/e5b22f68-d37d-4ace-911e-98f6a6700886) | api호출시 topicId 반환 |
| ![image](https://github.com/user-attachments/assets/f75b4056-98a9-4c1e-b008-e44676b91bdb) | db에도 저장된 모습 |

### 논의 사항 (선택)
- topicId가 3인 이유는 제가 앞서 테스트하느라 2개를 확인하고 나서 DELETE로 비우고 다시 저장해서 그렇습니다..

closed #45 