### PR TITLE
feat: 퀴즈 결과 제출 및 퀴즈 기록 저장 api 구현 

### DIFF
--- a/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
+++ b/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
@@ -16,7 +16,8 @@ public enum ErrorMessage {
 	DUPLICATE_EMAIL("이미 사용 중인 이메일입니다."),
 	INVALID_USER("회원 정보가 잘못되었습니다."),
 	NOT_FOUND_USER("존재하지 않는 회원입니다."),
-	NOT_FOUND_TOPIC("존재하지 않는 토픽입니다.");
+	NOT_FOUND_TOPIC("존재하지 않는 토픽입니다."),
+	EXCEEDS_TOTAL_COUNT("정답 개수가 전체 문제 수를 초과할 수 없습니다.");
 
 	public static final String INVALID_VALUE = "형식에 올바르게 작성해주세요.";
 

--- a/src/main/java/site/sonisori/sonisori/controller/QuizHistoryController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/QuizHistoryController.java
@@ -23,13 +23,13 @@ public class QuizHistoryController {
 	private final QuizHistoryService quizHistoryService;
 
 	@PostMapping("/topics/{topicId}/result")
-	public ResponseEntity<QuizHistoryResponse> submitQuizResult(
+	public ResponseEntity<QuizHistoryResponse> saveAndGetQuizResult(
 		@PathVariable("topicId") Long topicId,
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@RequestBody @Valid QuizHistoryRequest quizHistoryRequest
 	) {
 		Long userId = userDetails.getUserId();
-		QuizHistoryResponse response = quizHistoryService.submitQuizResult(
+		QuizHistoryResponse response = quizHistoryService.saveAndGetQuizResult(
 			userId, topicId, quizHistoryRequest
 		);
 		return ResponseEntity.ok(response);

--- a/src/main/java/site/sonisori/sonisori/controller/QuizHistoryController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/QuizHistoryController.java
@@ -1,0 +1,37 @@
+package site.sonisori.sonisori.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.auth.CustomUserDetails;
+import site.sonisori.sonisori.dto.quizhistory.QuizHistoryRequest;
+import site.sonisori.sonisori.dto.quizhistory.QuizHistoryResponse;
+import site.sonisori.sonisori.service.QuizHistoryService;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class QuizHistoryController {
+
+	private final QuizHistoryService quizHistoryService;
+
+	@PostMapping("/topics/{topicId}/result")
+	public ResponseEntity<QuizHistoryResponse> submitQuizResult(
+		@PathVariable("topicId") Long topicId,
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid QuizHistoryRequest quizHistoryRequest
+	) {
+		Long userId = userDetails.getUserId();
+		QuizHistoryResponse response = quizHistoryService.submitQuizResult(
+			userId, topicId, quizHistoryRequest
+		);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/site/sonisori/sonisori/dto/quizhistory/QuizHistoryRequest.java
+++ b/src/main/java/site/sonisori/sonisori/dto/quizhistory/QuizHistoryRequest.java
@@ -1,0 +1,12 @@
+package site.sonisori.sonisori.dto.quizhistory;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
+
+public record QuizHistoryRequest(
+	@NotNull(message = ErrorMessage.INVALID_VALUE)
+	@Min(value = 0, message = ErrorMessage.INVALID_VALUE)
+	int correctCount
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/dto/quizhistory/QuizHistoryResponse.java
+++ b/src/main/java/site/sonisori/sonisori/dto/quizhistory/QuizHistoryResponse.java
@@ -1,0 +1,8 @@
+package site.sonisori.sonisori.dto.quizhistory;
+
+public record QuizHistoryResponse(
+	String title,
+	int correctCount,
+	int totalQuizzes
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/entity/QuizHistory.java
+++ b/src/main/java/site/sonisori/sonisori/entity/QuizHistory.java
@@ -44,4 +44,14 @@ public class QuizHistory extends DateEntity {
 	@Column(name = "correct_count")
 	@Min(0)
 	private int correctCount;
+
+	public QuizHistory(User user, SignTopic signTopic, int correctCount) {
+		this.user = user;
+		this.signTopic = signTopic;
+		this.correctCount = correctCount;
+	}
+
+	public void updateCorrectCount(int correctCount) {
+		this.correctCount = correctCount;
+	}
 }

--- a/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/sonisori/sonisori/exception/GlobalExceptionHandler.java
@@ -73,6 +73,13 @@ public class GlobalExceptionHandler {
 			.body(new ErrorResponse(ErrorMessage.NULL_POINTER_EXCEPTION.getMessage()));
 	}
 
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+		logException(ex);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(new ErrorResponse(ex.getMessage()));
+	}
+
 	@ExceptionHandler(RuntimeException.class)
 	public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
 		logException(ex);

--- a/src/main/java/site/sonisori/sonisori/repository/QuizHistoryRepository.java
+++ b/src/main/java/site/sonisori/sonisori/repository/QuizHistoryRepository.java
@@ -1,6 +1,7 @@
 package site.sonisori.sonisori.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import site.sonisori.sonisori.entity.QuizHistory;
 
 public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
 	List<QuizHistory> findByUser_id(Long userId);
+
+	Optional<QuizHistory> findByUser_idAndSignTopic_id(Long userId, Long topicId);
 }

--- a/src/main/java/site/sonisori/sonisori/service/QuizHistoryService.java
+++ b/src/main/java/site/sonisori/sonisori/service/QuizHistoryService.java
@@ -1,6 +1,7 @@
 package site.sonisori.sonisori.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import site.sonisori.sonisori.common.constants.ErrorMessage;
@@ -21,7 +22,8 @@ public class QuizHistoryService {
 	private final SignTopicRepository signTopicRepository;
 	private final UserRepository userRepository;
 
-	public QuizHistoryResponse submitQuizResult(
+	@Transactional
+	public QuizHistoryResponse saveAndGetQuizResult(
 		Long userId, Long topicId, QuizHistoryRequest quizHistoryRequest
 	) {
 		User user = userRepository.findById(userId)
@@ -29,6 +31,9 @@ public class QuizHistoryService {
 		SignTopic signTopic = signTopicRepository.findById(topicId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_TOPIC.getMessage()));
 
+		if (quizHistoryRequest.correctCount() > signTopic.getTotalQuizzes()) {
+			throw new IllegalArgumentException(ErrorMessage.EXCEEDS_TOTAL_COUNT.getMessage());
+		}
 		QuizHistory quizHistory = QuizHistory.builder()
 			.user(user)
 			.signTopic(signTopic)

--- a/src/main/java/site/sonisori/sonisori/service/QuizHistoryService.java
+++ b/src/main/java/site/sonisori/sonisori/service/QuizHistoryService.java
@@ -1,0 +1,45 @@
+package site.sonisori.sonisori.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
+import site.sonisori.sonisori.dto.quizhistory.QuizHistoryRequest;
+import site.sonisori.sonisori.dto.quizhistory.QuizHistoryResponse;
+import site.sonisori.sonisori.entity.QuizHistory;
+import site.sonisori.sonisori.entity.SignTopic;
+import site.sonisori.sonisori.entity.User;
+import site.sonisori.sonisori.exception.NotFoundException;
+import site.sonisori.sonisori.repository.QuizHistoryRepository;
+import site.sonisori.sonisori.repository.SignTopicRepository;
+import site.sonisori.sonisori.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class QuizHistoryService {
+	private final QuizHistoryRepository quizHistoryRepository;
+	private final SignTopicRepository signTopicRepository;
+	private final UserRepository userRepository;
+
+	public QuizHistoryResponse submitQuizResult(
+		Long userId, Long topicId, QuizHistoryRequest quizHistoryRequest
+	) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_USER.getMessage()));
+		SignTopic signTopic = signTopicRepository.findById(topicId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_TOPIC.getMessage()));
+
+		QuizHistory quizHistory = QuizHistory.builder()
+			.user(user)
+			.signTopic(signTopic)
+			.correctCount(quizHistoryRequest.correctCount())
+			.build();
+		quizHistoryRepository.save(quizHistory);
+
+		return new QuizHistoryResponse(
+			signTopic.getTitle(),
+			quizHistoryRequest.correctCount(),
+			signTopic.getTotalQuizzes()
+		);
+	}
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 퀴즈 결과 제출 api를 작성하였습니다.
- api 호출 시 퀴즈 결과가 저장됩니다. 

### PR Point
- 코드를 실행하시기 전에 quiz_histories 테이블에서 count가 올바르게 삭제되었는지 확인해주세요 
- 삭제되어있지 않다면 해당 api 호출 시에 문제가 생깁니다.
- 우선 한 토픽에 대하여 여러번 퀴즈를 제출했을 경우 마지막으로 제출한 퀴즈의 기록만 보이게됩니다
  - 이 부분은 기획 관련된 부분으로.. 추후 퀴즈 제출 기록같은 UI를 만든다면 로직을 수정하겠습니다
  - 우선, 최후의 기록만 보이는 것 같아서 아래와 같이 로직을 작성하였습니다
    - 해당 topic에 대한 user의 기록이 없다면 새로 생성
    - 있다면, update 

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/a8ebe238-4bc5-4f5d-8156-196eabfa5206) | api 호출 시 |
| ![image](https://github.com/user-attachments/assets/f705fd3d-f730-44ad-91b4-d7dd914a4f86) | api 호출 후 isCompleted true로 수정됨 |
|![image](https://github.com/user-attachments/assets/24248522-617f-4238-b27e-fe89c5d1b25b)| 초과시 |
|![image](https://github.com/user-attachments/assets/1f2f91f9-2669-4f06-a569-34ca337d8602)| 기존 기록 update|

### 논의 사항 (선택)
- 논의할 사항이 있다면 적어주세요.

closed #39 