### PR TITLE
feat: 관리자 토픽삭제기능 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignTopicController.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,5 +41,11 @@ public class SignTopicController {
 	public ResponseEntity<SuccessResponse> addSignTopic(@Valid @RequestBody SignTopicRequest signTopicRequest) {
 		SuccessResponse successResponse = signTopicService.addSignTopic(signTopicRequest);
 		return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);
+	}
+
+	@DeleteMapping("/admin/topics/{topicId}")
+	public ResponseEntity<Void> deleteSignTopic(@PathVariable(name = "topicId") Long topicId) {
+		signTopicService.deleteSignTopic(topicId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
@@ -9,11 +9,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
 import site.sonisori.sonisori.common.response.SuccessResponse;
 import site.sonisori.sonisori.dto.signtopic.SignTopicRequest;
 import site.sonisori.sonisori.dto.signtopic.SignTopicResponse;
 import site.sonisori.sonisori.entity.QuizHistory;
 import site.sonisori.sonisori.entity.SignTopic;
+import site.sonisori.sonisori.exception.NotFoundException;
 import site.sonisori.sonisori.repository.QuizHistoryRepository;
 import site.sonisori.sonisori.repository.SignTopicRepository;
 
@@ -65,5 +67,13 @@ public class SignTopicService {
 		Long id = signTopicRepository.save(signTopic).getId();
 
 		return new SuccessResponse(id);
+	}
+
+	public void deleteSignTopic(Long topicId) {
+		if (!signTopicRepository.existsById(topicId)) {
+			throw new NotFoundException(ErrorMessage.NOT_FOUND_TOPIC.getMessage());
+		}
+
+		signTopicRepository.deleteById(topicId);
 	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 관리자 토픽 삭제 api를 구현하였습니다.

### PR Point
- 일반 USER권한으로 접근시 403에러, 존재하지 않는 topicId 삭제요청시 404에러, 성공시 204 로 구현하였습니다.
에러처리가 잘못된게 있는지 봐주세요!

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4aa97e94-d1c6-4463-a1cd-2d935ac9c206) | 유저 권한으로 접근시 |
| ![image](https://github.com/user-attachments/assets/11a60fa3-8efd-4171-817f-5c50d34425bb) | 존재하지 않는 topicId 삭제 요청시 |
| ![image](https://github.com/user-attachments/assets/fb0b5905-4866-485b-b3af-b18778bbf5c5)  | 삭제 요청 성공(DB에서도 잘 삭제됩니다!) |



closed #53 