### PR TITLE
feat: 관리자 퀴즈 추가 기능 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/controller/SignQuizController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignQuizController.java
@@ -2,13 +2,19 @@ package site.sonisori.sonisori.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.common.response.SuccessResponse;
+import site.sonisori.sonisori.dto.signquiz.SignQuizRequest;
 import site.sonisori.sonisori.dto.signquiz.SignQuizResponse;
 import site.sonisori.sonisori.service.SignQuizService;
 
@@ -25,5 +31,13 @@ public class SignQuizController {
 	) {
 		List<SignQuizResponse> signQuizzes = signQuizService.findQuizzesByTopicId(signTopicId);
 		return ResponseEntity.ok(signQuizzes);
+	}
+
+	@PostMapping("/admin/topics/{topicId}/quizzes")
+	public ResponseEntity<SuccessResponse> addQuizzes(@PathVariable(name = "topicId") Long topicId,
+		@Valid @RequestBody SignQuizRequest signQuizRequest
+	) {
+		SuccessResponse successResponse = signQuizService.addQuiz(topicId, signQuizRequest);
+		return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/dto/signquiz/SignQuizRequest.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signquiz/SignQuizRequest.java
@@ -1,0 +1,13 @@
+package site.sonisori.sonisori.dto.signquiz;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
+
+public record SignQuizRequest(
+	@NotBlank(message = ErrorMessage.INVALID_VALUE)
+	@Size(max = 255, message = ErrorMessage.INVALID_VALUE)
+	String sentence
+) {
+
+}

--- a/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
+++ b/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
@@ -57,4 +57,8 @@ public class SignTopic extends DateEntity {
 
 	@OneToMany(mappedBy = "signTopic", orphanRemoval = true)
 	private List<SignQuiz> signQuizzes;
+	
+	public void addTotalQuizzes() {
+		this.totalQuizzes++;
+	}
 }

--- a/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
+++ b/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
@@ -57,7 +57,7 @@ public class SignTopic extends DateEntity {
 
 	@OneToMany(mappedBy = "signTopic", orphanRemoval = true)
 	private List<SignQuiz> signQuizzes;
-	
+
 	public void addTotalQuizzes() {
 		this.totalQuizzes++;
 	}

--- a/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
@@ -4,11 +4,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import site.sonisori.sonisori.common.constants.ErrorMessage;
+import site.sonisori.sonisori.common.response.SuccessResponse;
+import site.sonisori.sonisori.dto.signquiz.SignQuizRequest;
 import site.sonisori.sonisori.dto.signquiz.SignQuizResponse;
 import site.sonisori.sonisori.entity.SignQuiz;
+import site.sonisori.sonisori.entity.SignTopic;
 import site.sonisori.sonisori.exception.NotFoundException;
 import site.sonisori.sonisori.repository.SignQuizRepository;
 import site.sonisori.sonisori.repository.SignTopicRepository;
@@ -23,7 +27,7 @@ public class SignQuizService {
 		Long signTopicId
 	) {
 		signTopicRepository.findById(signTopicId)
-			.orElseThrow(()-> new NotFoundException(ErrorMessage.NOT_FOUND_TOPIC.getMessage()));
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_TOPIC.getMessage()));
 
 		List<SignQuiz> signQuizzes = signQuizRepository.findAllBySignTopic_id(signTopicId);
 
@@ -32,5 +36,23 @@ public class SignQuizService {
 				quiz.getId(), quiz.getSentence()
 			))
 			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public SuccessResponse addQuiz(Long topicId, SignQuizRequest signQuizRequest) {
+		SignTopic signTopic = signTopicRepository.findById(topicId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_TOPIC.getMessage()));
+
+		SignQuiz signQuiz = SignQuiz.builder()
+			.signTopic(signTopic)
+			.sentence(signQuizRequest.sentence())
+			.build();
+
+		Long id = signQuizRepository.save(signQuiz).getId();
+
+		signTopic.addTotalQuizzes();
+		signTopicRepository.save(signTopic);
+
+		return new SuccessResponse(id);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignTopicService.java
@@ -77,6 +77,7 @@ public class SignTopicService {
 		signTopicRepository.deleteById(topicId);
 	}
 
+	@Transactional
 	public void updateSignTopic(Long topicId, SignTopicRequest signTopicRequest) {
 		SignTopic signTopic = signTopicRepository.findById(topicId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_TOPIC.getMessage()));

--- a/src/main/java/site/sonisori/sonisori/service/UserService.java
+++ b/src/main/java/site/sonisori/sonisori/service/UserService.java
@@ -90,6 +90,7 @@ public class UserService {
 			.build();
 	}
 
+	@Transactional
 	public void updateUserName(Long userId, UpdateUserNameRequest updateUserNameRequest) {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_USER.getMessage()));


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 관리자 퀴즈 추가 기능을 구현하였습니다.
- 퀴즈 추가시 201, USER권한 접근시 403에러, 존재하지 않는 토픽에 추가 시도시 404에러로 구현하였습니다.

### PR Point
- RequestBody양식은 topicId/topicName, sentence였으나 url에 입력되는 topicId를 활용하면 될 것 같아 sentence만 Request 받는 것으로 구현하였습니다.
- addQuiz 메서드로 퀴즈 추가시 SignTopic의 totalQuizzes를 +1 하도록 구현하였습니다.
- 예외처리 부분에서 놓친게 있나 확인해주세요.

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/5eae8d82-9386-4eaf-977c-42afc31ae320) | 퀴즈 추가 성공 |
| ![image](https://github.com/user-attachments/assets/2ea550da-65e9-4f22-a56e-ad00bae97c51) | DB에 추가된 퀴즈 모습 |
| ![image](https://github.com/user-attachments/assets/a3fb4922-16e9-4544-9136-3df7a60a1d02) | totalQuizzes가 1이 된 모습 |
| ![image](https://github.com/user-attachments/assets/f4b1c7e0-9cff-4fbd-98b5-db6dccb14bb4) | 존재하지 않는 토픽 접근 |
| ![image](https://github.com/user-attachments/assets/ba4b1d70-d6f6-426c-94ce-7885fc9f6336) | USER권한 접근 |


closed #59 