### PR TITLE
feat: 관리자 퀴즈 삭제기능 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
+++ b/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
@@ -19,7 +19,8 @@ public enum ErrorMessage {
 	NOT_FOUND_USER("존재하지 않는 회원입니다."),
 	NOT_FOUND_TOPIC("존재하지 않는 토픽입니다."),
 	NOT_FOUND_QUIZ("존재하지 않는 퀴즈입니다."),
-	EXCEEDS_TOTAL_COUNT("정답 개수가 전체 문제 수를 초과할 수 없습니다.");
+	EXCEEDS_TOTAL_COUNT("정답 개수가 전체 문제 수를 초과할 수 없습니다."),
+	UNDER_QUIZ_COUNT("퀴즈 개수는 최소 0개 이상이어야 합니다.");
 
 	public static final String INVALID_VALUE = "형식에 올바르게 작성해주세요.";
 

--- a/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
+++ b/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
@@ -18,6 +18,7 @@ public enum ErrorMessage {
 	INVALID_USER("회원 정보가 잘못되었습니다."),
 	NOT_FOUND_USER("존재하지 않는 회원입니다."),
 	NOT_FOUND_TOPIC("존재하지 않는 토픽입니다."),
+	NOT_FOUND_QUIZ("존재하지 않는 퀴즈입니다."),
 	EXCEEDS_TOTAL_COUNT("정답 개수가 전체 문제 수를 초과할 수 없습니다.");
 
 	public static final String INVALID_VALUE = "형식에 올바르게 작성해주세요.";

--- a/src/main/java/site/sonisori/sonisori/controller/SignQuizController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignQuizController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,10 +35,17 @@ public class SignQuizController {
 	}
 
 	@PostMapping("/admin/topics/{topicId}/quizzes")
-	public ResponseEntity<SuccessResponse> addQuizToTopic(@PathVariable(name = "topicId") Long topicId,
+	public ResponseEntity<SuccessResponse> addQuizToTopicByAdmin(@PathVariable(name = "topicId") Long topicId,
 		@Valid @RequestBody SignQuizRequest signQuizRequest
 	) {
 		SuccessResponse successResponse = signQuizService.addQuiz(topicId, signQuizRequest);
 		return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);
+	}
+
+	@DeleteMapping("/admin/quizzes/{quizId}")
+	public ResponseEntity<Void> deleteQuizByAdmin(@PathVariable(name = "quizId") Long quizId
+	) {
+		signQuizService.deleteQuiz(quizId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
+++ b/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.sonisori.sonisori.common.DateEntity;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
 import site.sonisori.sonisori.common.enums.Difficulty;
 
 @Entity
@@ -63,7 +64,11 @@ public class SignTopic extends DateEntity {
 	}
 
 	public void decrementTotalQuizzes() {
-		this.totalQuizzes--;
+		if (this.totalQuizzes > 0) {
+			this.totalQuizzes--;
+		} else {
+			throw new IllegalArgumentException(ErrorMessage.UNDER_QUIZ_COUNT.getMessage());
+		}
 	}
 
 	public void updateTopic(String newTitle, String newContents, Difficulty newDifficulty) {

--- a/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
+++ b/src/main/java/site/sonisori/sonisori/entity/SignTopic.java
@@ -62,6 +62,10 @@ public class SignTopic extends DateEntity {
 		this.totalQuizzes++;
 	}
 
+	public void decrementTotalQuizzes() {
+		this.totalQuizzes--;
+	}
+
 	public void updateTopic(String newTitle, String newContents, Difficulty newDifficulty) {
 		this.title = newTitle;
 		this.contents = newContents;

--- a/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
@@ -60,8 +60,7 @@ public class SignQuizService {
 		SignQuiz signQuiz = signQuizRepository.findById(quizId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_QUIZ.getMessage()));
 
-		SignTopic signTopic = signQuiz.getSignTopic();
-		signTopic.decrementTotalQuizzes();
+		signQuiz.getSignTopic().decrementTotalQuizzes();
 
 		signQuizRepository.deleteById(quizId);
 	}

--- a/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
@@ -54,4 +54,15 @@ public class SignQuizService {
 
 		return new SuccessResponse(id);
 	}
+
+	@Transactional
+	public void deleteQuiz(Long quizId) {
+		SignQuiz signQuiz = signQuizRepository.findById(quizId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_QUIZ.getMessage()));
+
+		SignTopic signTopic = signQuiz.getSignTopic();
+		signTopic.decrementTotalQuizzes();
+
+		signQuizRepository.deleteById(quizId);
+	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 관리자 권한으로 퀴즈를 삭제하는 api 기능을 구현하였습니다.
- 존재하지 않는 quizId에 접근시 404에러, USER권한 접근시 403에러, 성공시 204를 반환하도록 구현하였습니다.

### PR Point
- 전달받은 quizId를 이용해 signTopic을 찾고 decrementTotalQuizzes 메서드를 구현하여 totalQuizzes 가 -1이 되도록 구현하였습니다.
- 놓친 예외처리 부분이 있나 봐주세요!

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/a437ced6-a54c-46f2-9286-87bc700d0d5c) | 존재하지 않는 퀴즈 접근 |
| ![image](https://github.com/user-attachments/assets/5f101ed7-d159-4832-b20c-6069a0b3cca2) | 퀴즈 삭제 성공 |
| ![image](https://github.com/user-attachments/assets/54c65cf8-59b7-49ee-a014-cfce98823355) | 삭제 후 퀴즈가 1개만 남은 모습 |
| ![image](https://github.com/user-attachments/assets/aa073671-679b-4b1f-bb88-9805fd2782cd) | 삭제 후 totalQuizzes가 1이 된 모습 |
| ![image](https://github.com/user-attachments/assets/1e87aa82-0bda-4956-b357-385695d8ca02) | USER권한 접근 |




closed #61 