### PR TITLE
Fix: Elastic Beanstalk 환경 상태가 Ready가 아닌 경우 배포가 실패하는 문제 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,4 +27,5 @@ jobs:
           version_label: "github-action-${{ github.sha }}-${{ github.run_number }}"
           region: ${{ secrets.AWS_REGION }}
           deployment_package: Dockerrun.aws.json
+          wait_for_deployment: true
           wait_for_environment_recovery: 180


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 배포 실패 원인인 환경 상태 확인 로직을 개선하여, 상태가 유효하지 않으면 배포를 진행하지 않도록 수정했습니다.

closed #67 