### PR TITLE
feat: 관리자 퀴즈 수정기능 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/controller/SignQuizController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignQuizController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,6 +47,14 @@ public class SignQuizController {
 	public ResponseEntity<Void> deleteQuizByAdmin(@PathVariable(name = "quizId") Long quizId
 	) {
 		signQuizService.deleteQuiz(quizId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@PatchMapping("/admin/quizzes/{quizId}")
+	public ResponseEntity<Void> updateQuizByAdmin(@PathVariable(name = "quizId") Long quizId,
+		@Valid @RequestBody SignQuizRequest signQuizRequest
+	) {
+		signQuizService.updateQuiz(quizId, signQuizRequest);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/entity/SignQuiz.java
+++ b/src/main/java/site/sonisori/sonisori/entity/SignQuiz.java
@@ -41,4 +41,7 @@ public class SignQuiz extends DateEntity {
 	@Size(max = 255)
 	private String sentence;
 
+	public void updateSentence(String sentence) {
+		this.sentence = sentence;
+	}
 }

--- a/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignQuizService.java
@@ -64,4 +64,12 @@ public class SignQuizService {
 
 		signQuizRepository.deleteById(quizId);
 	}
+
+	@Transactional
+	public void updateQuiz(Long quizId, SignQuizRequest signQuizRequest) {
+		SignQuiz signQuiz = signQuizRepository.findById(quizId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_QUIZ.getMessage()));
+
+		signQuiz.updateSentence(signQuizRequest.sentence());
+	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 관리자 권한으로 퀴즈를 수정하는 api 기능을 구현하였습니다.
- 존재하지 않는 퀴즈 접근시 404에러, USER권한 접근시 403에러, 수정 성공시 204로 구현하였습니다.

### PR Point
- @transactional 을 추가하고 dirty_checking을 이용하여 updateQuiz메서드에 save를 생략하였습니다. 

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ee776c35-4c52-4e30-83ee-a61acebf2f7f) | 퀴즈 수정 성공 |
| ![image](https://github.com/user-attachments/assets/65115c27-79bb-404c-bc33-346f3c49f327) | DB에서 수정된 모습 |
| ![image](https://github.com/user-attachments/assets/03ffc77c-522d-49cc-987a-68f38e472564) | 존재하지 않는 퀴즈 접근 |
| ![image](https://github.com/user-attachments/assets/ccfc3e87-0d75-47f1-932e-db4890d622de) | USER권한으로 접근 |


closed #66 