### PR TITLE
feat: 수어 사전 단어 추가 api 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
@@ -2,12 +2,18 @@ package site.sonisori.sonisori.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.common.response.SuccessResponse;
+import site.sonisori.sonisori.dto.signword.SignWordRequest;
 import site.sonisori.sonisori.dto.signword.SignWordResponse;
 import site.sonisori.sonisori.service.SignWordService;
 
@@ -21,5 +27,11 @@ public class SignWordController {
 	public ResponseEntity<List<SignWordResponse>> getAllSignWords() {
 		List<SignWordResponse> signWords = signWordService.getAllSignWords();
 		return ResponseEntity.ok(signWords);
+	}
+
+	@PostMapping("/admin/words")
+	public ResponseEntity<SuccessResponse> addSignWordByAdmin(@RequestBody @Valid SignWordRequest signWordRequest) {
+		SuccessResponse successResponse = signWordService.addSignWord(signWordRequest);
+		return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/dto/signword/SignWordRequest.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signword/SignWordRequest.java
@@ -1,0 +1,15 @@
+package site.sonisori.sonisori.dto.signword;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
+
+public record SignWordRequest(
+	@NotBlank(message = ErrorMessage.INVALID_VALUE)
+	@Size(max = 50, message = ErrorMessage.INVALID_VALUE)
+	String word,
+
+	@Size(max = 500, message = ErrorMessage.INVALID_VALUE)
+	String description
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/service/SignWordService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignWordService.java
@@ -4,8 +4,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.common.response.SuccessResponse;
+import site.sonisori.sonisori.dto.signword.SignWordRequest;
 import site.sonisori.sonisori.dto.signword.SignWordResponse;
 import site.sonisori.sonisori.entity.SignWord;
 import site.sonisori.sonisori.repository.SignWordRepository;
@@ -20,5 +23,16 @@ public class SignWordService {
 		return signWords.stream()
 			.map(SignWord::toDto)
 			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public SuccessResponse addSignWord(SignWordRequest signWordRequest) {
+		SignWord signWord = SignWord.builder()
+			.word(signWordRequest.word())
+			.description(signWordRequest.description())
+			.build();
+
+		Long id = signWordRepository.save(signWord).getId();
+		return new SuccessResponse(id);
 	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 수어 사전 단어 추가 api를 구현하였습니다.

### PR Point
- description이 null 인 단어도 있어, description은 not null 처리를 하지 않았습니다.

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/c1c6121d-400a-4019-ae6a-27a5c2f9d65a)| 일반 유저 |
|![image](https://github.com/user-attachments/assets/dc1569de-7967-4f0e-802d-c0ff4d2a5ad1)| 추가 성공 |

### 논의 사항 (선택)
- 논의할 사항이 있다면 적어주세요.

closed #75 