### PR TITLE
feat: 관리자 단어 삭제기능 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
+++ b/src/main/java/site/sonisori/sonisori/common/constants/ErrorMessage.java
@@ -19,6 +19,7 @@ public enum ErrorMessage {
 	NOT_FOUND_USER("존재하지 않는 회원입니다."),
 	NOT_FOUND_TOPIC("존재하지 않는 토픽입니다."),
 	NOT_FOUND_QUIZ("존재하지 않는 퀴즈입니다."),
+	NOT_FOUND_WORD("존재하지 않는 단어입니다."),
 	EXCEEDS_TOTAL_COUNT("정답 개수가 전체 문제 수를 초과할 수 없습니다."),
 	UNDER_QUIZ_COUNT("퀴즈 개수는 최소 0개 이상이어야 합니다.");
 

--- a/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,5 +35,13 @@ public class SignWordController {
 	public ResponseEntity<SuccessResponse> addSignWordByAdmin(@RequestBody @Valid SignWordRequest signWordRequest) {
 		SuccessResponse successResponse = signWordService.addSignWord(signWordRequest);
 		return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);
+	}
+
+	@DeleteMapping("/admin/words/{wordId}")
+	public ResponseEntity<Void> deleteSignWordByAdmin(
+		@PathVariable(name = "wordId") Long wordId
+	) {
+		signWordService.deleteSignWord(wordId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/service/SignWordService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignWordService.java
@@ -7,10 +7,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import site.sonisori.sonisori.common.constants.ErrorMessage;
 import site.sonisori.sonisori.common.response.SuccessResponse;
 import site.sonisori.sonisori.dto.signword.SignWordRequest;
 import site.sonisori.sonisori.dto.signword.SignWordResponse;
 import site.sonisori.sonisori.entity.SignWord;
+import site.sonisori.sonisori.exception.NotFoundException;
 import site.sonisori.sonisori.repository.SignWordRepository;
 
 @Service
@@ -34,5 +36,13 @@ public class SignWordService {
 
 		Long id = signWordRepository.save(signWord).getId();
 		return new SuccessResponse(id);
+	}
+
+	public void deleteSignWord(Long wordId) {
+		if (!signWordRepository.existsById(wordId)) {
+			throw new NotFoundException(ErrorMessage.NOT_FOUND_WORD.getMessage());
+		}
+
+		signWordRepository.deleteById(wordId);
 	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 관리자 권한으로 단어를 삭제하는 api 기능을 구현하였습니다.
- 존재하지 않는 단어 접근시 404에러, USER권한 접근시 403에러, 삭제 성공시 204로 구현하였습니다.


### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/b4355448-020f-4c1d-8751-352ffaaccefe) | 단어 삭제 성공 |
|![image](https://github.com/user-attachments/assets/82756aaf-65ed-46f9-b08a-7c17367d99a3) | 존재 하지 않는 단어 접근|
|![image](https://github.com/user-attachments/assets/b653ac2b-4870-4177-a655-bb171434b1fe) | USER권한 접근 |
| ![image](https://github.com/user-attachments/assets/0a594ba6-137a-4ed3-80ac-328fbe1d747a) | 잘 삭제된 모습 |



### 논의 사항 (선택)
- 논의할 사항이 있다면 적어주세요.

closed #80 