### PR TITLE
feat: 단어 개별 조회 api 구현 (+oauth2 경로 추가, cascade 설정 추가)

### DIFF
--- a/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
+++ b/src/main/java/site/sonisori/sonisori/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests((auth) ->
 				auth
 					.requestMatchers(
-						"/login/oauth2/code/*", "/api/auth/signup", "/api/auth/login", "/api/auth"
+						"/login/**", "/api/auth/signup", "/api/auth/login", "/api/auth"
 					).permitAll()
 					.requestMatchers("/api/admin/**").hasRole("ADMIN")
 					.anyRequest().authenticated()

--- a/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
@@ -33,7 +33,7 @@ public class SignWordController {
 	}
 
 	@GetMapping("/words/{wordId}")
-	public ResponseEntity<SignWordDetailResponse> getSignWordDetail(
+	public ResponseEntity<SignWordDetailResponse> getSignWordDetails(
 		@PathVariable(name = "wordId") Long wordId
 	) {
 		SignWordDetailResponse signWordDetail = signWordService.getSignWordDetail(wordId);

--- a/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.sonisori.sonisori.common.response.SuccessResponse;
+import site.sonisori.sonisori.dto.signword.SignWordDetailResponse;
 import site.sonisori.sonisori.dto.signword.SignWordRequest;
 import site.sonisori.sonisori.dto.signword.SignWordResponse;
 import site.sonisori.sonisori.service.SignWordService;
@@ -29,6 +30,14 @@ public class SignWordController {
 	public ResponseEntity<List<SignWordResponse>> getAllSignWords() {
 		List<SignWordResponse> signWords = signWordService.getAllSignWords();
 		return ResponseEntity.ok(signWords);
+	}
+
+	@GetMapping("/words/{wordId}")
+	public ResponseEntity<SignWordDetailResponse> getSignWordDetail(
+		@PathVariable(name = "wordId") Long wordId
+	) {
+		SignWordDetailResponse signWordDetail = signWordService.getSignWordDetail(wordId);
+		return ResponseEntity.ok(signWordDetail);
 	}
 
 	@PostMapping("/admin/words")

--- a/src/main/java/site/sonisori/sonisori/dto/signword/SignWordDetailResponse.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signword/SignWordDetailResponse.java
@@ -1,0 +1,12 @@
+package site.sonisori.sonisori.dto.signword;
+
+import java.util.List;
+
+import site.sonisori.sonisori.dto.signwordresource.SignWordResourceDto;
+
+public record SignWordDetailResponse(
+	String word,
+	String description,
+	List<SignWordResourceDto> resources
+) {
+}

--- a/src/main/java/site/sonisori/sonisori/dto/signwordresource/SignWordResourceDto.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signwordresource/SignWordResourceDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import site.sonisori.sonisori.common.enums.ResourceType;
 
-public record SignWordResourceRequest(
+public record SignWordResourceDto(
 	@NotNull
 	ResourceType resourceType,
 

--- a/src/main/java/site/sonisori/sonisori/dto/signwordresource/SignWordResourceListRequest.java
+++ b/src/main/java/site/sonisori/sonisori/dto/signwordresource/SignWordResourceListRequest.java
@@ -8,6 +8,6 @@ import jakarta.validation.constraints.Size;
 public record SignWordResourceListRequest(
 	@NotNull
 	@Size(min = 1)
-	List<SignWordResourceRequest> resources
+	List<SignWordResourceDto> resources
 ) {
 }

--- a/src/main/java/site/sonisori/sonisori/entity/SignWord.java
+++ b/src/main/java/site/sonisori/sonisori/entity/SignWord.java
@@ -1,10 +1,14 @@
 package site.sonisori.sonisori.entity;
 
+import java.util.List;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -35,6 +39,9 @@ public class SignWord extends DateEntity {
 	@Column(name = "description")
 	@Size(max = 500)
 	private String description;
+
+	@OneToMany(mappedBy = "signWord", fetch = FetchType.LAZY)
+	private List<SignWordResource> signWordResources;
 
 	public SignWordResponse toDto() {
 		return new SignWordResponse(this.id, this.word);

--- a/src/main/java/site/sonisori/sonisori/service/SignWordService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignWordService.java
@@ -9,8 +9,10 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import site.sonisori.sonisori.common.constants.ErrorMessage;
 import site.sonisori.sonisori.common.response.SuccessResponse;
+import site.sonisori.sonisori.dto.signword.SignWordDetailResponse;
 import site.sonisori.sonisori.dto.signword.SignWordRequest;
 import site.sonisori.sonisori.dto.signword.SignWordResponse;
+import site.sonisori.sonisori.dto.signwordresource.SignWordResourceDto;
 import site.sonisori.sonisori.entity.SignWord;
 import site.sonisori.sonisori.exception.NotFoundException;
 import site.sonisori.sonisori.repository.SignWordRepository;
@@ -25,6 +27,22 @@ public class SignWordService {
 		return signWords.stream()
 			.map(SignWord::toDto)
 			.collect(Collectors.toList());
+	}
+
+	@Transactional(readOnly = true)
+	public SignWordDetailResponse getSignWordDetail(Long wordId) {
+		SignWord signWord = signWordRepository.findById(wordId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_WORD.getMessage()));
+
+		List<SignWordResourceDto> resources = signWord.getSignWordResources().stream()
+			.map(resource -> new SignWordResourceDto(resource.getResourceType(), resource.getResourceUrl()))
+			.toList();
+
+		return new SignWordDetailResponse(
+			signWord.getWord(),
+			signWord.getDescription(),
+			resources
+		);
 	}
 
 	@Transactional

--- a/src/main/java/site/sonisori/sonisori/service/SignWordService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignWordService.java
@@ -14,6 +14,7 @@ import site.sonisori.sonisori.dto.signword.SignWordRequest;
 import site.sonisori.sonisori.dto.signword.SignWordResponse;
 import site.sonisori.sonisori.dto.signwordresource.SignWordResourceDto;
 import site.sonisori.sonisori.entity.SignWord;
+import site.sonisori.sonisori.entity.SignWordResource;
 import site.sonisori.sonisori.exception.NotFoundException;
 import site.sonisori.sonisori.repository.SignWordRepository;
 
@@ -34,15 +35,19 @@ public class SignWordService {
 		SignWord signWord = signWordRepository.findById(wordId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_WORD.getMessage()));
 
-		List<SignWordResourceDto> resources = signWord.getSignWordResources().stream()
-			.map(resource -> new SignWordResourceDto(resource.getResourceType(), resource.getResourceUrl()))
-			.toList();
+		List<SignWordResourceDto> resources = mapSignWordResources(signWord.getSignWordResources());
 
 		return new SignWordDetailResponse(
 			signWord.getWord(),
 			signWord.getDescription(),
 			resources
 		);
+	}
+
+	private List<SignWordResourceDto> mapSignWordResources(List<SignWordResource> resources) {
+		return resources.stream()
+			.map(resource -> new SignWordResourceDto(resource.getResourceType(), resource.getResourceUrl()))
+			.toList();
 	}
 
 	@Transactional

--- a/src/main/resources/db/migration/V5__add_cascade_settings.sql
+++ b/src/main/resources/db/migration/V5__add_cascade_settings.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `sonisori`.`sign_word_resources`
+DROP FOREIGN KEY `fk_sign-word-resources_sign-word_id`;
+ALTER TABLE `sonisori`.`sign_word_resources`
+    ADD CONSTRAINT `fk_sign-word-resources_sign-word_id`
+        FOREIGN KEY (`sign_word_id`)
+            REFERENCES `sonisori`.`sign_words` (`id`)
+            ON DELETE CASCADE;


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 단어 개별(디테일) 조회 api를 구현하였습니다.
- 단어와 설명, 이미지 url과 video url을 포함합니다. 


### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/ef8f0391-c148-40a8-ad3c-380e334abec6) | 디테일 조회 1|
|![image](https://github.com/user-attachments/assets/0b275c65-3561-48d3-a095-0f3dd8799c62)|디테일 조회 2|
|![image](https://github.com/user-attachments/assets/4532d6b2-f970-40e0-b7df-4b6af604e28f)|존재하지 않는 단어|

### 논의 사항 (선택)
- 논의할 사항이 있다면 적어주세요.

closed #74 