### PR TITLE
feat: 관리자 단어 수정기능 구현

### DIFF
--- a/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
+++ b/src/main/java/site/sonisori/sonisori/controller/SignWordController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,6 +43,14 @@ public class SignWordController {
 		@PathVariable(name = "wordId") Long wordId
 	) {
 		signWordService.deleteSignWord(wordId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@PatchMapping("/admin/words/{wordId}")
+	public ResponseEntity<Void> updateSignWordByAdmin(@Valid @RequestBody SignWordRequest signWordRequest,
+		@PathVariable(name = "wordId") Long wordId
+	) {
+		signWordService.updateSignWord(wordId, signWordRequest);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/site/sonisori/sonisori/entity/SignWord.java
+++ b/src/main/java/site/sonisori/sonisori/entity/SignWord.java
@@ -39,4 +39,9 @@ public class SignWord extends DateEntity {
 	public SignWordResponse toDto() {
 		return new SignWordResponse(this.id, this.word);
 	}
+
+	public void updateWord(String word, String description) {
+		this.word = word;
+		this.description = description;
+	}
 }

--- a/src/main/java/site/sonisori/sonisori/service/SignWordService.java
+++ b/src/main/java/site/sonisori/sonisori/service/SignWordService.java
@@ -45,4 +45,12 @@ public class SignWordService {
 
 		signWordRepository.deleteById(wordId);
 	}
+
+	@Transactional
+	public void updateSignWord(Long wordId, SignWordRequest signWordRequest) {
+		SignWord signWord = signWordRepository.findById(wordId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_WORD.getMessage()));
+
+		signWord.updateWord(signWordRequest.word(), signWordRequest.description());
+	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 관리자 기능으로 단어를 수정하는 api를 구현하였습니다.
- 없는 단어 접근시 404, USER권한 접근시 403, 수정 성공시 204로 구현하였습니다.


### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

| 사진 | 설명 |
| --- | --- |
|![image](https://github.com/user-attachments/assets/c597a25c-5b0c-45d1-9b71-3ff8990b27af) | 수정 성공 |
|![image](https://github.com/user-attachments/assets/c07568e9-80c3-40ef-9dd2-defc14ca7de6) | DB에 반영된 모습 |
|![image](https://github.com/user-attachments/assets/a36cdbc1-e764-4f98-aed4-0ffbc05e70f2) | 존재하지 않는 단어 접근 |
|![image](https://github.com/user-attachments/assets/21dfd7c2-c7d9-46e4-bd83-c292210a498a) | USER권한 접근 |


closed #84 